### PR TITLE
Enable dae format

### DIFF
--- a/Project/Registry/sceneassetimporter.setreg
+++ b/Project/Registry/sceneassetimporter.setreg
@@ -1,0 +1,40 @@
+{
+	"O3DE":
+	{
+		"SceneAPI":
+		{
+			"AssetImporter":
+			{
+				"SupportedFileTypeExtensions":
+				[
+					".dae",
+					".fbx",
+					".stl",
+					".gltf",
+					".glb"
+				]
+			},
+			"MaterialConverter": 
+			{
+				"Enable": true,
+				"DefaultMaterial": "Materials/Presets/PBR/default_grid.material"
+			},
+			"TangentGenerateComponent":
+			{
+				"DefaultGenerationMethod": "FromSourceScene",
+				"DebugBitangentFlip": false
+			},
+			"SkinRule":
+			{
+				"DefaultMaxSkinInfluencesPerVertex": 8,
+				"DefaultWeightThreshold": 0.001
+			},
+			"ModelBuilder": 
+			{
+				// When false, scenes with multiple meshes assigned to the same material but with different vertex layouts will successfully process
+				// When true, stricter error checking will cause the asset to fail to process with an error message indicating why
+				"MismatchedVertexLayoutsAreErrors": false 
+			}
+		}
+	}
+}


### PR DESCRIPTION
Draft - I am figuring out how to use .setregpatch instead, such as:

```
[
    { "op": "replace", "path": "/O3DE/SceneAPI/AssetImporter/SupportedFileTypeExtensions", "value": [ ".dae", ".fbx", ".stl", ".glft", ".glb" ] }
]
```

Signed-off-by: Adam Dabrowski <adam.dabrowski@robotec.ai>