### PR TITLE
[Do not merge] Deappletreeized orchad

### DIFF
--- a/Project/Levels/Main/Main.prefab
+++ b/Project/Levels/Main/Main.prefab
@@ -36,6 +36,10 @@
                 "$type": "EditorEntitySortComponent",
                 "Id": 14126657869720434043,
                 "Child Entity Order": [
+                    "Instance_[1065623388407703]/ContainerEntity",
+                    "Instance_[1067809526761367]/ContainerEntity",
+                    "Entity_[17223493880265070]",
+                    "Instance_[1069690722437015]/ContainerEntity",
                     "Entity_[1176639161715]",
                     "Instance_[937084723552]/ContainerEntity",
                     "Entity_[1078906895689]",
@@ -66,11 +70,7 @@
                     "Entity_[203531967850072]",
                     "Entity_[3093375998176916]",
                     "Entity_[6435574917698725]",
-                    "Entity_[9579063166563054]",
-                    "Entity_[7184523221940590]",
-                    "Entity_[11555842151561582]",
-                    "Entity_[11574632633481582]",
-                    "Entity_[17223493880265070]"
+                    "Entity_[9579063166563054]"
                 ]
             },
             "Component_[14409887347711167786]": {
@@ -668,16 +668,32 @@
                 },
                 "Component_[5265045084611556958]": {
                     "$type": "EditorDisabledCompositionComponent",
-                    "Id": 5265045084611556958
+                    "Id": 5265045084611556958,
+                    "DisabledComponents": [
+                        {
+                            "$type": "AZ::Render::EditorBloomComponent",
+                            "Id": 8967653191103446244,
+                            "Controller": {
+                                "Configuration": {
+                                    "Enabled": true,
+                                    "Knee": 0.5799999833106995,
+                                    "Intensity": 0.05000000074505806
+                                }
+                            }
+                        }
+                    ]
                 },
                 "Component_[6360183481254267636]": {
                     "$type": "AZ::Render::EditorSsaoComponent",
                     "Id": 6360183481254267636,
                     "Controller": {
                         "Configuration": {
+                            "Enabled": false,
                             "Strength": 0.3199999928474426,
                             "SamplingRadius": 0.07750000059604645,
-                            "BlurDepthFalloffStrength": 184.0
+                            "EnableBlur": false,
+                            "BlurDepthFalloffStrength": 184.0,
+                            "EnableDownsample": false
                         }
                     }
                 },
@@ -694,8 +710,7 @@
                             "FogStartDistance": 0.0,
                             "FogEndDistance": 600.0,
                             "FogMinHeight": 0.0,
-                            "FogMaxHeight": 35.0,
-                            "EnableFogLayerShaderOption": true
+                            "FogMaxHeight": 35.0
                         }
                     }
                 },
@@ -717,17 +732,6 @@
                 "Component_[8866210352157164042]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 8866210352157164042
-                },
-                "Component_[8967653191103446244]": {
-                    "$type": "AZ::Render::EditorBloomComponent",
-                    "Id": 8967653191103446244,
-                    "Controller": {
-                        "Configuration": {
-                            "Enabled": true,
-                            "Knee": 0.5799999833106995,
-                            "Intensity": 0.05000000074505806
-                        }
-                    }
                 },
                 "Component_[9129253381063760879]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -774,7 +778,7 @@
                         "randomSeed": 25
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[11657126070335854]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -875,7 +879,7 @@
                         "randomSeed": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[11657130365303150]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -971,7 +975,7 @@
                         "frequency": 0.1922709047794342
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[11657134660270446]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -1066,7 +1070,7 @@
                         "randomSeed": 51
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[11657138955237742]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -1589,7 +1593,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1201954005397140]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -1691,7 +1695,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1201958300364436]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -1814,7 +1818,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1201962595331732]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -1889,7 +1893,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1201966890299028]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -1986,7 +1990,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1201971185266324]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -2109,7 +2113,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1201975480233620]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -2179,7 +2183,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1201979775200916]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -2501,7 +2505,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1201988365135508]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -2844,7 +2848,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1201996955070100]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -3160,7 +3164,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1202005545004692]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -3230,7 +3234,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1202009839971988]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -3547,7 +3551,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1202018429906580]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -3642,7 +3646,7 @@
                         "randomSeed": 25
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[12761907622984046]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -3738,7 +3742,7 @@
                         "frequency": 0.1922709047794342
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[12761911917951342]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -3833,7 +3837,7 @@
                         "randomSeed": 51
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[12761916212918638]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -3934,7 +3938,7 @@
                         "randomSeed": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[12761920507885934]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -4304,7 +4308,7 @@
                         "frequency": 0.1922709047794342
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[12922234457176430]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -4399,7 +4403,7 @@
                         "randomSeed": 25
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[12922238752143726]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -4500,7 +4504,7 @@
                         "randomSeed": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[12922243047111022]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -4869,7 +4873,7 @@
                         "randomSeed": 51
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[12922251637045614]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -4964,7 +4968,7 @@
                         "randomSeed": 25
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[13453470372084078]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -5060,7 +5064,7 @@
                         "frequency": 0.1922709047794342
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[13453474667051374]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -5161,7 +5165,7 @@
                         "randomSeed": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[13453478962018670]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -5256,7 +5260,7 @@
                         "randomSeed": 51
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[13453483256985966]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -5625,7 +5629,7 @@
                         "randomSeed": 25
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[14042563791436142]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -5721,7 +5725,7 @@
                         "frequency": 0.1922709047794342
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[14042568086403438]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -5816,7 +5820,7 @@
                         "randomSeed": 51
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[14042572381370734]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -5917,7 +5921,7 @@
                         "randomSeed": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[14042576676338030]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -6289,7 +6293,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1574615432769172]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -6412,7 +6416,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1574619727736468]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -6482,7 +6486,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1574624022703764]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -6605,7 +6609,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1574628317671060]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -6701,7 +6705,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1574632612638356]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -6771,7 +6775,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1574641202572948]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -6873,7 +6877,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1574645497540244]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -6975,7 +6979,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1574649792507540]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -7517,7 +7521,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1574662677409428]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -7953,7 +7957,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1961516426450979]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -8023,7 +8027,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1961525016385571]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -8345,7 +8349,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[1961533606320163]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -8566,7 +8570,7 @@
                     "$type": "EditorImageGradientComponent",
                     "Id": 6913475367130875979,
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[296994751178328]"
                     },
                     "Configuration": {
                         "StreamingImageAsset": {
@@ -8769,7 +8773,7 @@
                     "$type": "EditorImageGradientComponent",
                     "Id": 10707924659521035089,
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[357799673674485]"
                     },
                     "Configuration": {
                         "StreamingImageAsset": {
@@ -8852,7 +8856,7 @@
                     "$type": "EditorImageGradientComponent",
                     "Id": 10707924659521035089,
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[357812558576373]"
                     },
                     "Configuration": {
                         "StreamingImageAsset": {
@@ -9125,7 +9129,7 @@
                     "$type": "EditorImageGradientComponent",
                     "Id": 10707924659521035089,
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[382784004585584]"
                     },
                     "Configuration": {
                         "StreamingImageAsset": {
@@ -9208,7 +9212,7 @@
                     "$type": "EditorImageGradientComponent",
                     "Id": 10707924659521035089,
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[382814069356656]"
                     },
                     "Configuration": {
                         "StreamingImageAsset": {
@@ -9544,7 +9548,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[519388226871594]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -9667,7 +9671,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[519392521838890]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -9742,7 +9746,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[519396816806186]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -9844,7 +9848,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[550433236397716]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -9941,7 +9945,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[550437531365012]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -10038,7 +10042,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[550441826332308]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -10140,7 +10144,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[550446121299604]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -10483,7 +10487,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[550454711234196]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -10799,7 +10803,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[550463301168788]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -10971,7 +10975,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711322711305876]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -11046,7 +11050,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711327006273172]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -11143,7 +11147,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711331301240468]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -11245,7 +11249,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711335596207764]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -11368,7 +11372,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711339891175060]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -11438,7 +11442,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711344186142356]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -11535,7 +11539,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711348481109652]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -11852,7 +11856,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711357071044244]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -11954,7 +11958,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711361366011540]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -12056,7 +12060,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711365660978836]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -12399,7 +12403,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711374250913428]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -12935,7 +12939,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[711387135815316]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -13103,7 +13107,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926723911134868]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -13199,7 +13203,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926728206102164]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -13269,7 +13273,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926732501069460]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -13366,7 +13370,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926736796036756]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -13463,7 +13467,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926741091004052]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -13586,7 +13590,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926745385971348]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -13661,7 +13665,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926749680938644]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -13784,7 +13788,7 @@
                         "RandomSeed": 8
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926753975905940]"
                     }
                 },
                 "Component_[6450143247629463722]": {
@@ -13859,7 +13863,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926758270873236]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -14181,7 +14185,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926766860807828]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -14283,7 +14287,7 @@
                         "octave": 7
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926771155775124]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -14600,7 +14604,7 @@
                         "frequency": 2.5765879154205322
                     },
                     "Previewer": {
-                        "BoundsEntity": ""
+                        "BoundsEntity": "Entity_[926779745709716]"
                     }
                 },
                 "Component_[2076736657326245564]": {
@@ -19553,6 +19557,31 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[17478803486732630354]/Transform Data/UniformScale",
                     "value": 1.5
+                }
+            ]
+        },
+        "Instance_[843883654373596]": {
+            "Source": "Assets/Importer/apple_kraken.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[17071299421335020589]/Parent Entity",
+                    "value": "../Entity_[1146574390643]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[17071299421335020589]/Transform Data/Translate/0",
+                    "value": -40.28277587890625
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[17071299421335020589]/Transform Data/Translate/1",
+                    "value": 48.11690139770508
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[17071299421335020589]/Transform Data/Translate/2",
+                    "value": -0.0000019073486328125
                 }
             ]
         },

--- a/Project/Prefabs/AppleTreeNoApples.prefab
+++ b/Project/Prefabs/AppleTreeNoApples.prefab
@@ -1,0 +1,456 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "AppleTreeNoFruits",
+        "Components": {
+            "Component_[13780854788209656370]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 13780854788209656370
+            },
+            "Component_[14844147111191371400]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 14844147111191371400
+            },
+            "Component_[17787362634089348803]": {
+                "$type": "EditorLockComponent",
+                "Id": 17787362634089348803
+            },
+            "Component_[17843908741683212556]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 17843908741683212556
+            },
+            "Component_[2636528230258506924]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 2636528230258506924
+            },
+            "Component_[2919361912050306087]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 2919361912050306087,
+                "Parent Entity": ""
+            },
+            "Component_[4620877604030964358]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 4620877604030964358,
+                "Child Entity Order": [
+                    "Entity_[691956415503188]",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Instance_[421093742146431]/ContainerEntity",
+                    "",
+                    "",
+                    ""
+                ]
+            },
+            "Component_[6545066386370449417]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 6545066386370449417
+            },
+            "Component_[7635208911897638298]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 7635208911897638298
+            },
+            "Component_[7786292261310069513]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 7786292261310069513
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[691956415503188]": {
+            "Id": "Entity_[691956415503188]",
+            "Name": "AppleTree",
+            "Components": {
+                "Component_[10483984395814518873]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 10483984395814518873,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{3B449F7F-C3DE-561D-AA71-7A26EFD48957}",
+                                    "subId": 280458798
+                                },
+                                "assetHint": "assets/apple_tree/appletree.azmodel"
+                            },
+                            "SortKey": 3,
+                            "LodType": 1
+                        }
+                    }
+                },
+                "Component_[10868288372941810356]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10868288372941810356
+                },
+                "Component_[12444622250145591703]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12444622250145591703,
+                    "Parent Entity": "ContainerEntity",
+                    "IsStatic": true
+                },
+                "Component_[15156623641462766583]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15156623641462766583
+                },
+                "Component_[15752591005564428774]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15752591005564428774
+                },
+                "Component_[2232052990511423151]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2232052990511423151
+                },
+                "Component_[3894251219152098730]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 3894251219152098730,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 199226484
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{55339E98-54B6-5D38-B182-262882507562}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_branchmat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 924759392
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{A9A7956A-79C1-53A1-95C1-342AC7C3E8FB}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_leaf_sss_mat.azmaterial"
+                                        },
+                                        "PropertyOverrides": {
+                                            "baseColor.color": {
+                                                "$type": "Color",
+                                                "Value": [
+                                                    0.48235294222831726,
+                                                    0.48235294222831726,
+                                                    0.48235294222831726,
+                                                    1.0
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 1288673165
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{B03382D7-0965-53E2-A0CE-C526142FAFB8}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_treemat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 0,
+                                        "materialSlotStableId": 199226484
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{55339E98-54B6-5D38-B182-262882507562}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_branchmat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 0,
+                                        "materialSlotStableId": 924759392
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{A9A7956A-79C1-53A1-95C1-342AC7C3E8FB}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_leaf_sss_mat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 0,
+                                        "materialSlotStableId": 1288673165
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{B03382D7-0965-53E2-A0CE-C526142FAFB8}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_treemat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 1,
+                                        "materialSlotStableId": 199226484
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{55339E98-54B6-5D38-B182-262882507562}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_branchmat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 1,
+                                        "materialSlotStableId": 924759392
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{A9A7956A-79C1-53A1-95C1-342AC7C3E8FB}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_leaf_sss_mat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 1,
+                                        "materialSlotStableId": 1288673165
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{B03382D7-0965-53E2-A0CE-C526142FAFB8}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_treemat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 2,
+                                        "materialSlotStableId": 199226484
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{5751E3F7-A665-52B0-A371-D3A7D37C6CC3}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_branch_basemat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 2,
+                                        "materialSlotStableId": 924759392
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{EB582A15-08B3-59E8-870C-59249E92D948}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_leaf_basemat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 2,
+                                        "materialSlotStableId": 1288673165
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{A2C3ED2A-B141-5FAB-B07D-147EFFE5F034}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_tree_basemat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 3,
+                                        "materialSlotStableId": 199226484
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{5751E3F7-A665-52B0-A371-D3A7D37C6CC3}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_branch_basemat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 3,
+                                        "materialSlotStableId": 924759392
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{EB582A15-08B3-59E8-870C-59249E92D948}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_leaf_basemat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 3,
+                                        "materialSlotStableId": 1288673165
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{A2C3ED2A-B141-5FAB-B07D-147EFFE5F034}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_tree_basemat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 4,
+                                        "materialSlotStableId": 199226484
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{5751E3F7-A665-52B0-A371-D3A7D37C6CC3}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_branch_basemat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 4,
+                                        "materialSlotStableId": 924759392
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{A9A7956A-79C1-53A1-95C1-342AC7C3E8FB}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_leaf_sss_mat.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "lodIndex": 4,
+                                        "materialSlotStableId": 1288673165
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{A2C3ED2A-B141-5FAB-B07D-147EFFE5F034}"
+                                            },
+                                            "assetHint": "assets/apple_tree/appletree_tree_basemat.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "materialSlotsByLodEnabled": true
+                },
+                "Component_[5042179235701765609]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5042179235701765609
+                },
+                "Component_[546308243281095224]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 546308243281095224
+                },
+                "Component_[6111505743688272735]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6111505743688272735,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12444622250145591703
+                        },
+                        {
+                            "ComponentId": 10483984395814518873,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17286267979684003150,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[8148146872807561086]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8148146872807561086
+                }
+            }
+        }
+    },
+    "Instances": {
+        "Instance_[421093742146431]": {
+            "Source": "Prefabs/GrassTileMed.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[2832389859834261345]/Parent Entity",
+                    "value": "../ContainerEntity"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[2832389859834261345]/Transform Data/Translate/0",
+                    "value": 0.019669830799102783
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[2832389859834261345]/Transform Data/Translate/1",
+                    "value": -0.010040462017059326
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[2832389859834261345]/Transform Data/Translate/2",
+                    "value": -0.03808104991912842
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[2832389859834261345]/Transform Data/UniformScale",
+                    "value": 0.5
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
 - Added prefab `AppleTreeNoFruits`
 - Prefabs in rows were replaced with `AppleTreeNoFruits`
 - Three original `AppleTree` prefabs were added

With these few changes, our team can tune localization, and motion planning on the full scene, enjoying the performance.
On my machine, 25-30 fps are displayed when looking at the orchard (3000x1851 resolution). The fps goes to 60 when I look in the sky - which is an indication that the limiting factor is Vulkan, not PhysX.