### PR TITLE
Follow camera improvements

### DIFF
--- a/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.cpp
+++ b/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.cpp
@@ -1,19 +1,18 @@
 /*
-* Copyright (c) Contributors to the Open 3D Engine Project.
-* For complete copyright and license terms please see the LICENSE at the root of this distribution.
-*
-* SPDX-License-Identifier: Apache-2.0 OR MIT
-*
-*/
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
 
 #include "FollowingCameraComponent.h"
 
-#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
 #include <MathConversion.h>
-
 
 namespace AppleKraken
 {
@@ -29,7 +28,10 @@ namespace AppleKraken
                 ->Field("Target", &FollowingCameraComponent::m_target)
                 ->Field("SmoothingLength", &FollowingCameraComponent::m_smoothingBuffer)
                 ->Field("ZoomSpeed", &FollowingCameraComponent::m_zoomSpeed)
-                ->Field("RotationSpeed", &FollowingCameraComponent::m_rotationSpeed);
+                ->Field("RotationSpeed", &FollowingCameraComponent::m_rotationSpeed)
+                ->Field("MinCameraDistance", &FollowingCameraComponent::m_min_camera_distance)
+                ->Field("MaxCameraDistance", &FollowingCameraComponent::m_max_camera_distance)
+                ->Field("LookAtCenterEntity", &FollowingCameraComponent::m_look_at_center_entity);
 
             AZ::EditContext* editContext = serializeContext->GetEditContext();
             if (editContext)
@@ -39,10 +41,33 @@ namespace AppleKraken
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
                     ->Attribute(AZ::Edit::Attributes::Category, "AppleKraken")
                     ->DataElement(AZ::Edit::UIHandlers::CheckBox, &FollowingCameraComponent::m_isActive, "Active", "")
-                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &FollowingCameraComponent::m_target, "Target", "Entity of the followed object")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &FollowingCameraComponent::m_target, "SmoothingLength", "Number of past transform used to smooth")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::EntityId, &FollowingCameraComponent::m_target, "Target", "Entity of the followed object")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &FollowingCameraComponent::m_target,
+                        "SmoothingLength",
+                        "Number of past transform used to smooth")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &FollowingCameraComponent::m_zoomSpeed, "Zoom Speed", "Zoom speed")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &FollowingCameraComponent::m_rotationSpeed, "Rotation Speed", "Rotation Speed");
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &FollowingCameraComponent::m_rotationSpeed, "Rotation Speed", "Rotation Speed")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &FollowingCameraComponent::m_min_camera_distance,
+                        "Min. Camera Distance",
+                        "Camera move-foreward limit")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &FollowingCameraComponent::m_max_camera_distance,
+                        "Max. Camera Distance",
+                        "Camera move-backward limit")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &FollowingCameraComponent::m_look_at_center_entity,
+                        "Look At Center Entity",
+                        "If true, camera will be rotatet to look at the rotation center entity");
             }
         }
     }
@@ -60,8 +85,6 @@ namespace AppleKraken
     {
         InputChannelEventListener::Connect();
         AZ::TickBus::Handler::BusConnect();
-
-        EBUS_EVENT_ID_RESULT(m_initialPose, GetEntityId(), AZ::TransformBus, GetLocalTM);
     }
 
     void FollowingCameraComponent::Deactivate()
@@ -72,7 +95,8 @@ namespace AppleKraken
 
     void FollowingCameraComponent::OnTick(float deltaTime, AZ::ScriptTimePoint /*time*/)
     {
-        if (!m_target.IsValid()){
+        if (!m_target.IsValid())
+        {
             AZ_Warning("FollowingCameraComponent", false, "m_target is empty!");
         }
         if (!m_isActive)
@@ -80,49 +104,71 @@ namespace AppleKraken
             return;
         }
 
-        AZ::Transform target_world_transform;
-        EBUS_EVENT_ID_RESULT(target_world_transform, m_target, AZ::TransformBus, GetWorldTM);
+        if (!m_activated)
+        {
+            if (m_look_at_center_entity)
+            {
+                // m_target may be not initiated on Activate(). We have to wait for it.
+                AZ::Transform center_transform;
+                EBUS_EVENT_ID_RESULT(center_transform, m_target, AZ::TransformBus, GetWorldTM);
+                AZ::Transform self_transform;
+                EBUS_EVENT_ID_RESULT(self_transform, GetEntityId(), AZ::TransformBus, GetWorldTM);
 
-        m_lastTransforms.push_back(AZStd::make_pair(target_world_transform.GetTranslation(), deltaTime));
-        if (m_lastTransforms.size() > m_smoothingBuffer){
-            m_lastTransforms.pop_front();
+                if (!center_transform.IsFinite() || !self_transform.IsFinite())
+                {
+                    return;
+                }
+
+                AZ::Transform new_pose = AZ::Transform::CreateLookAt(self_transform.GetTranslation(), center_transform.GetTranslation());
+                new_pose.SetTranslation(self_transform.GetTranslation());
+                EBUS_EVENT_ID(GetEntityId(), AZ::TransformBus, SetWorldTM, new_pose);
+            }
+
+            EBUS_EVENT_ID_RESULT(m_initialPose, GetEntityId(), AZ::TransformBus, GetLocalTM);
+            m_activated = true;
         }
-        AZ::Vector3 translation = SmoothTranslation();
+        else
+        {
+            AZ::Transform target_world_transform;
+            EBUS_EVENT_ID_RESULT(target_world_transform, m_target, AZ::TransformBus, GetWorldTM);
 
-        AZ::Transform filtered_transform =
+            m_lastTransforms.push_back(AZStd::make_pair(target_world_transform.GetTranslation(), deltaTime));
+            if (m_lastTransforms.size() > m_smoothingBuffer)
             {
-                translation,
-                AZ::Quaternion::CreateRotationZ(target_world_transform.GetEulerRadians().GetZ()),
-                target_world_transform.GetUniformScale()
-            };
+                m_lastTransforms.pop_front();
+            }
+            AZ::Vector3 translation = SmoothTranslation();
 
-        auto modified_transform = m_initialPose.GetInverse();
-        AZ::Transform rotation_transform =
-            {
-                {0.0, 0.0, 0.0},
-               AZ::Quaternion::CreateRotationY(m_rotationChange2) *  AZ::Quaternion::CreateRotationZ(m_rotationChange) ,
-                1.0
-            };
-        modified_transform *= rotation_transform;
-        modified_transform.Invert();
+            AZ::Transform filtered_transform = { translation,
+                                                 AZ::Quaternion::CreateRotationZ(target_world_transform.GetEulerRadians().GetZ()),
+                                                 target_world_transform.GetUniformScale() };
 
-        AZ::Vector3 translation_modifier = modified_transform.GetBasisY() * m_zoomChange;
-        auto modified_translation = modified_transform.GetTranslation() + translation_modifier;
-        modified_transform.SetTranslation( modified_translation );
+            auto modified_transform = m_initialPose.GetInverse();
+            AZ::Transform rotation_transform = { { 0.0, 0.0, 0.0 },
+                                                 AZ::Quaternion::CreateRotationY(m_rotationChange2) *
+                                                     AZ::Quaternion::CreateRotationZ(m_rotationChange),
+                                                 1.0 };
+            modified_transform *= rotation_transform;
+            modified_transform.Invert();
 
-        EBUS_EVENT_ID(GetEntityId(), AZ::TransformBus, SetWorldTM, filtered_transform * modified_transform);
+            AZ::Vector3 translation_modifier = modified_transform.GetBasisY() * m_zoomChange;
+            auto modified_translation = modified_transform.GetTranslation() + translation_modifier;
+            modified_transform.SetTranslation(modified_translation);
 
+            EBUS_EVENT_ID(GetEntityId(), AZ::TransformBus, SetWorldTM, filtered_transform * modified_transform);
+        }
     }
 
     AZ::Vector3 FollowingCameraComponent::SmoothTranslation() const
     {
-        AZ::Vector3 sum{0};
-        float normalization{0};
-        for (const auto& p : m_lastTransforms){
+        AZ::Vector3 sum{ 0 };
+        float normalization{ 0 };
+        for (const auto& p : m_lastTransforms)
+        {
             sum += p.first * p.second;
-            normalization+=p.second;
+            normalization += p.second;
         }
-        return sum/normalization;
+        return sum / normalization;
     }
 
     bool FollowingCameraComponent::OnInputChannelEventFiltered(const AzFramework::InputChannel& inputChannel)
@@ -149,11 +195,16 @@ namespace AppleKraken
             return;
         }
 
+        if (m_min_camera_distance > m_max_camera_distance)
+        {
+            m_max_camera_distance = m_min_camera_distance;
+        }
+
         const AzFramework::InputChannelId& channelId = inputChannel.GetInputChannelId();
         // TODO take into account the refresh rate on key pressed for smooth experience
         if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericW)
         {
-            m_zoomChange = AZStd::min(m_zoomMax, m_zoomChange + m_zoomSpeed);
+            m_zoomChange = AZStd::min((-m_min_camera_distance + 2.0f), m_zoomChange + m_zoomSpeed);
         }
         if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericA)
         {
@@ -165,7 +216,7 @@ namespace AppleKraken
         }
         if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericS)
         {
-            m_zoomChange = AZStd::max(m_zoomMin, m_zoomChange - m_zoomSpeed);
+            m_zoomChange = AZStd::max(-m_max_camera_distance, m_zoomChange - m_zoomSpeed);
         }
 
         if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericD)
@@ -176,6 +227,5 @@ namespace AppleKraken
         {
             m_rotationChange2 -= m_rotationSpeed;
         }
-
     }
-}
+} // namespace AppleKraken

--- a/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.cpp
+++ b/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.cpp
@@ -124,6 +124,8 @@ namespace AppleKraken
                 EBUS_EVENT_ID(GetEntityId(), AZ::TransformBus, SetWorldTM, new_pose);
             }
 
+            // TODO using GetLocalTM here may lead to problems, if the camera is not in the top level of prefab hierarchy. To be tested and
+            // considered to use GetWorldTM instead
             EBUS_EVENT_ID_RESULT(m_initialPose, GetEntityId(), AZ::TransformBus, GetLocalTM);
             m_activated = true;
         }

--- a/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.cpp
+++ b/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.cpp
@@ -45,7 +45,7 @@ namespace AppleKraken
                         AZ::Edit::UIHandlers::EntityId, &FollowingCameraComponent::m_target, "Target", "Entity of the followed object")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &FollowingCameraComponent::m_target,
+                        &FollowingCameraComponent::m_smoothingBuffer,
                         "SmoothingLength",
                         "Number of past transform used to smooth")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &FollowingCameraComponent::m_zoomSpeed, "Zoom Speed", "Zoom speed")
@@ -66,7 +66,7 @@ namespace AppleKraken
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &FollowingCameraComponent::m_look_at_center_entity,
-                        "Look At Center Entity",
+                        "Look At Target",
                         "If true, camera will be rotatet to look at the rotation center entity");
             }
         }

--- a/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.cpp
+++ b/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.cpp
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project.
- * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- *
- * SPDX-License-Identifier: Apache-2.0 OR MIT
- *
- */
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
 
 #include "FollowingCameraComponent.h"
 
@@ -29,9 +29,9 @@ namespace AppleKraken
                 ->Field("SmoothingLength", &FollowingCameraComponent::m_smoothingBuffer)
                 ->Field("ZoomSpeed", &FollowingCameraComponent::m_zoomSpeed)
                 ->Field("RotationSpeed", &FollowingCameraComponent::m_rotationSpeed)
-                ->Field("MinCameraDistance", &FollowingCameraComponent::m_min_camera_distance)
-                ->Field("MaxCameraDistance", &FollowingCameraComponent::m_max_camera_distance)
-                ->Field("LookAtCenterEntity", &FollowingCameraComponent::m_look_at_center_entity);
+                ->Field("MinCameraDistance", &FollowingCameraComponent::m_minCameraDistance)
+                ->Field("MaxCameraDistance", &FollowingCameraComponent::m_maxCameraDistance)
+                ->Field("LookAtCenterEntity", &FollowingCameraComponent::m_lookAtCenterEntity);
 
             AZ::EditContext* editContext = serializeContext->GetEditContext();
             if (editContext)
@@ -53,19 +53,19 @@ namespace AppleKraken
                         AZ::Edit::UIHandlers::Default, &FollowingCameraComponent::m_rotationSpeed, "Rotation Speed", "Rotation Speed")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &FollowingCameraComponent::m_min_camera_distance,
+                        &FollowingCameraComponent::m_minCameraDistance,
                         "Min. Camera Distance",
                         "Camera move-foreward limit")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &FollowingCameraComponent::m_max_camera_distance,
+                        &FollowingCameraComponent::m_maxCameraDistance,
                         "Max. Camera Distance",
                         "Camera move-backward limit")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &FollowingCameraComponent::m_look_at_center_entity,
+                        &FollowingCameraComponent::m_lookAtCenterEntity,
                         "Look At Target",
                         "If true, camera will be rotatet to look at the rotation center entity");
             }
@@ -104,11 +104,13 @@ namespace AppleKraken
             return;
         }
 
+        // Check, if the component was already activated (initialized). If not, perform activation. 
         if (!m_activated)
         {
-            if (m_look_at_center_entity)
+            if (m_lookAtCenterEntity)
             {
-                // m_target may be not initiated on Activate(). We have to wait for it.
+                // Some initiatialization tasks can not be done in the Activate(), because m_target entitie may not be accessible at that 
+                // moment. We must wait for it.  
                 AZ::Transform center_transform;
                 EBUS_EVENT_ID_RESULT(center_transform, m_target, AZ::TransformBus, GetWorldTM);
                 AZ::Transform self_transform;
@@ -197,16 +199,16 @@ namespace AppleKraken
             return;
         }
 
-        if (m_min_camera_distance > m_max_camera_distance)
+        if (m_minCameraDistance > m_maxCameraDistance)
         {
-            m_max_camera_distance = m_min_camera_distance;
+            m_maxCameraDistance = m_minCameraDistance;
         }
 
         const AzFramework::InputChannelId& channelId = inputChannel.GetInputChannelId();
         // TODO take into account the refresh rate on key pressed for smooth experience
         if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericW)
         {
-            m_zoomChange = AZStd::min((-m_min_camera_distance + 2.0f), m_zoomChange + m_zoomSpeed);
+            m_zoomChange = AZStd::min((-m_minCameraDistance + 2.0f), m_zoomChange + m_zoomSpeed);
         }
         if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericA)
         {
@@ -218,7 +220,7 @@ namespace AppleKraken
         }
         if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericS)
         {
-            m_zoomChange = AZStd::max(-m_max_camera_distance, m_zoomChange - m_zoomSpeed);
+            m_zoomChange = AZStd::max(-m_maxCameraDistance, m_zoomChange - m_zoomSpeed);
         }
 
         if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericD)

--- a/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.h
+++ b/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.h
@@ -10,8 +10,8 @@
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
-#include <AzFramework/Input/Events/InputChannelEventListener.h>
 #include <AzFramework/Components/TransformComponent.h>
+#include <AzFramework/Input/Events/InputChannelEventListener.h>
 
 namespace AppleKraken
 {
@@ -27,17 +27,17 @@ namespace AppleKraken
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
 
         static void Reflect(AZ::ReflectContext* reflection);
-        
+
         AZ_COMPONENT(FollowingCameraComponent, "{92317883-9956-455E-9A1C-BF8986DC2F80}", AZ::Component);
-        
+
         // AZ::Component
         void Init() override;
         void Activate() override;
         void Deactivate() override;
-        
+
         // AZ::TickBus
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
-        
+
         // AzFramework::InputChannelEventListener
         bool OnInputChannelEventFiltered(const AzFramework::InputChannel& inputChannel) override;
 
@@ -55,7 +55,6 @@ namespace AppleKraken
         float m_rotationChange = 0.0f;
         float m_rotationChange2 = 0.0f;
 
-
         float m_zoomChange = 0.0f;
 
         int m_smoothingBuffer = 30;
@@ -63,11 +62,13 @@ namespace AppleKraken
         float m_zoomSpeed = 0.06f;
         float m_rotationSpeed = 0.05f;
 
-        const float m_zoomMin = -25.f;
-        const float m_zoomMax = 0.6f;
+        float m_min_camera_distance = 1.5f;
+        float m_max_camera_distance = 25.0f;
 
+        bool m_look_at_center_entity = false;
 
-        AZStd::deque<AZStd::pair<AZ::Vector3,float>> m_lastTransforms;
+        bool m_activated = false;
 
+        AZStd::deque<AZStd::pair<AZ::Vector3, float>> m_lastTransforms;
     };
-}
+} // namespace AppleKraken

--- a/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.h
+++ b/Project/Gem/Source/KrakenCamera/FollowingCameraComponent.h
@@ -62,10 +62,10 @@ namespace AppleKraken
         float m_zoomSpeed = 0.06f;
         float m_rotationSpeed = 0.05f;
 
-        float m_min_camera_distance = 1.5f;
-        float m_max_camera_distance = 25.0f;
+        float m_minCameraDistance = 1.5f;
+        float m_maxCameraDistance = 25.0f;
 
-        bool m_look_at_center_entity = false;
+        bool m_lookAtCenterEntity = false;
 
         bool m_activated = false;
 


### PR DESCRIPTION
Introduced 2 improvements to the `follow camera` component:

- Ability to define min and max camera distance from the UI.
- Added `Look at center entity` UI option. When activated, the camera will be rotated to look at the center entity. It makes it more convenient to set camera rotation this way.