### PR TITLE
Run docker build from the repo subdirectory to avoid large context transfers

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,8 @@ the demo in this repository.
 To build the Dockerfile the only required step is to clone first the ROSConDemo:
 ```
 git clone git@github.com:aws-lumberyard/ROSConDemo.git
-docker build -t roscon_demo -f ROSConDemo/docker/Dockerfile .
+cd ROSConDemo/docker
+docker build -t roscon_demo -f Dockerfile .
 ```
 
 Note: the build process is going to download all the necessary assets for running


### PR DESCRIPTION
Should help to avoid #193 situations. Fix #193