### PR TITLE
Galactic support for the Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
-FROM ros:humble-ros-core-jammy
+ARG ROS_VERSION=humble
+ARG UBUNTU_VERSION=jammy
+FROM ros:${ROS_VERSION}-ros-core-${UBUNTU_VERSION}
 
+ARG ROS_VERSION
 ENV WORKDIR=/data/workspace
 WORKDIR $WORKDIR
 
@@ -66,14 +69,14 @@ RUN apt-get update && apt-get install -y \
 
 # Gem + ROSConDemo ROS pacakges
 RUN apt-get update && apt-get install -y \
-    ros-humble-ackermann-msgs \
-    ros-humble-control-toolbox \
-    ros-humble-gazebo-msgs \
-    ros-humble-navigation2 \
-    ros-humble-rviz2 \
-    ros-humble-tf2-ros \
-    ros-humble-urdfdom \
-    ros-humble-vision-msgs \
+    ros-${ROS_VERSION}-ackermann-msgs \
+    ros-${ROS_VERSION}-control-toolbox \
+    ros-${ROS_VERSION}-gazebo-msgs \
+    ros-${ROS_VERSION}-navigation2 \
+    ros-${ROS_VERSION}-rviz2 \
+    ros-${ROS_VERSION}-tf2-ros \
+    ros-${ROS_VERSION}-urdfdom \
+    ros-${ROS_VERSION}-vision-msgs \
     && rm -rf /var/lib/apt/lists/*
 
 ## Symlink clang version to non-versioned clang and set cc to clang
@@ -104,29 +107,29 @@ RUN ./o3de/scripts/o3de.sh register --this-engine \
 WORKDIR $WORKDIR/ROSConDemo/Project
 
 RUN git lfs pull \
-    && . /opt/ros/humble/setup.sh \
+    && . /opt/ros/${ROS_VERSION}/setup.sh \
     && cmake -B build/linux -S . -G "Ninja Multi-Config" -DLY_STRIP_DEBUG_SYMBOLS=ON
 
-RUN . /opt/ros/humble/setup.sh \
+RUN . /opt/ros/${ROS_VERSION}/setup.sh \
     && cmake --build build/linux --config profile --target ROSConDemo Editor AssetProcessor
 
 # This final step takes long since they Assets will be downloading
-RUN . /opt/ros/humble/setup.sh \
+RUN . /opt/ros/${ROS_VERSION}/setup.sh \
     && echo "This final step can take more than 1 hour. Good time for going for a coffee :)" \
     && cmake --build build/linux --config profile --target ROSConDemo.Assets
 
 # Installing o3de_kraken_nav
 RUN apt-get update && apt-get install -y \
     python3-colcon-common-extensions \
-    ros-humble-cyclonedds \
-    ros-humble-rmw-cyclonedds-cpp \
-    ros-humble-slam-toolbox \
-    ros-humble-navigation2 \
-    ros-humble-nav2-bringup \
-    ros-humble-pointcloud-to-laserscan \
-    ros-humble-teleop-twist-keyboard \
-    ros-humble-ackermann-msgs \
-    ros-humble-topic-tools \
+    ros-${ROS_VERSION}-cyclonedds \
+    ros-${ROS_VERSION}-rmw-cyclonedds-cpp \
+    ros-${ROS_VERSION}-slam-toolbox \
+    ros-${ROS_VERSION}-navigation2 \
+    ros-${ROS_VERSION}-nav2-bringup \
+    ros-${ROS_VERSION}-pointcloud-to-laserscan \
+    ros-${ROS_VERSION}-teleop-twist-keyboard \
+    ros-${ROS_VERSION}-ackermann-msgs \
+    ros-${ROS_VERSION}-topic-tools \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install python-statemachine

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
     bind9-utils \
     binutils \
     ca-certificates \
-    clang \
+    clang-12 \
     cmake \
     file \
     firewalld \
@@ -79,9 +79,20 @@ RUN apt-get update && apt-get install -y \
     ros-${ROS_VERSION}-vision-msgs \
     && rm -rf /var/lib/apt/lists/*
 
+# Focal needs a modern version for CMake since it
+RUN if [ "${ROS_VERSION}" = "galactic" ]; then \
+      wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
+        gpg --dearmor - | \
+        tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+      && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | \
+        tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+      && apt-get update && apt-get install -y cmake=3.24.1-0kitware1ubuntu20.04.1 \
+      && rm -rf /var/lib/apt/lists/*; \
+    fi
+
 ## Symlink clang version to non-versioned clang and set cc to clang
-RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100 \
-    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-12 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-12 100
 
 # Assumes a local checkout of private ROSConDemo
 RUN git clone https://github.com/o3de/ROSConDemo.git \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,7 +87,9 @@ RUN if [ "${ROS_VERSION}" = "galactic" ]; then \
         tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
       && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | \
         tee /etc/apt/sources.list.d/kitware.list >/dev/null \
-      && apt-get update && apt-get install -y cmake=3.24.1-0kitware1ubuntu20.04.1 \
+      && apt-get update && apt-get install -y \
+        cmake=3.24.1-0kitware1ubuntu20.04.1 \
+        cmake-data=3.24.1-0kitware1ubuntu20.04.1 \
       && rm -rf /var/lib/apt/lists/*; \
     fi
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -58,4 +58,4 @@ to execute the Editor.
 ```
 
 Continue with the instruction in the
-[main README file](https://github.com/o3de/ROSConDemo/blob/main/README.md).
+[main README file](../README.md).

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,8 +1,12 @@
 # Dockerfile for running the ROSConDemo
 
-The Dockerfile is going to create an Ubuntu Jammy + ROS Humble platform
-that prepares the O3DE simulator together with the o3de-ros2-gem to run
-the demo in this repository.
+
+The Dockerfile is going to create an image that prepares the O3DE simulator
+together with the o3de-ros2-gem and o3de_kraken_nav to run the demo hosted
+in this repository.
+
+The image by default will use Ubuntu Jammy and ROS 2 Humble but can also
+be configured to use Ubuntu Focal and ROS 2 Galactic.
 
 ## Requisites
 
@@ -10,17 +14,30 @@ the demo in this repository.
  * At least 40GB of free disk space
  * The build process can take more than 2 hours
 
-## Building the Docker Image
+Note: the build process is going to download all the necessary assets for running
+the demo so it can take several hours depending on the Internet connection.
 
-To build the Dockerfile the only required step is to clone first the ROSConDemo:
+## Building the default Docker Image (Ubuntu Jammy + ROS 2 Humble)
+
+Creating the image using the Dockerfile to have an Ubuntu Jammy and ROS 2
+Humble platform requires just to have docker installed:
+
 ```
-git clone git@github.com:aws-lumberyard/ROSConDemo.git
-cd ROSConDemo/docker
+wget https://raw.githubusercontent.com/o3de/ROSConDemo/main/docker/Dockerfile
 docker build -t roscon_demo -f Dockerfile .
 ```
 
-Note: the build process is going to download all the necessary assets for running
-the demo so it can take several hours depending on the Internet connection.
+## Building the Docker Image using Ubuntu Focal and ROS 2 Galactic
+
+Creating the image using the Dockerfile to have an Ubuntu Focal and ROS 2
+Galactic platform requires just to have docker installed and provide some
+extra building arguments to it:
+
+```
+wget https://raw.githubusercontent.com/o3de/ROSConDemo/main/docker/Dockerfile
+docker build -t roscon_demo_galactic --build-arg ROS_VERSION=galactic --build-arg UBUNTU_VERSION=focal  .
+```
+
 
 ## Running the Docker Image
 
@@ -41,4 +58,4 @@ to execute the Editor.
 ```
 
 Continue with the instruction in the
-[main README file](https://github.com/aws-lumberyard/ROSConDemo/blob/main/README.md).
+[main README file](https://github.com/o3de/ROSConDemo/blob/main/README.md).


### PR DESCRIPTION
The PR implements the Galactic support for the current Dockerfile. It was not difficult and the only big problem found were the compiler errors of default clang in Ubuntu Focal. Steps:

 * Parametrize the Dockerfile to support build-args UBUNTU_VERSION and ROS_VERSION 985d23a0bccd4c45665bf48894dec7cb9fb430aa
 * Use clang-12 and on Focal install CMake 3.14 (thanks to @spham-amzn) 6bde42a3b1a02ca5324664f1aafa26e751f07606
 * Update README instructions deb535838ac12aad929c4b72479f68b7099e7d6a

I've changed the README to just use the raw Dockerfile instead of cloning the whole repository.  Added the Galactic instructions and  update the repository URLs.

Fix: #196 

