### PR TITLE
Update docker script

### DIFF
--- a/Project/Registry/autoexec.game.setreg
+++ b/Project/Registry/autoexec.game.setreg
@@ -2,7 +2,8 @@
     "O3DE": {
         "Autoexec":{
             "ConsoleCommands": {
-                "bg_ConnectToAssetProcessor":false
+                "bg_ConnectToAssetProcessor":false,
+                "LoadLevel": "main"
             }
         }
     }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,12 +4,44 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 
-FROM ros:humble-ros-core-jammy
+# Collect the arguments for the base ros image
+ARG ROS_VERSION=humble
+ARG UBUNTU_VERSION=jammy
 
-ENV WORKDIR=/data/workspace
-WORKDIR $WORKDIR
+FROM ros:${ROS_VERSION}-ros-base-${UBUNTU_VERSION}
 
+ARG ROS_VERSION
+ARG UBUNTU_VERSION
+
+# Argument to control the type of docker image to build
+ARG IMAGE_TYPE=simulation  # Default to 'simulation'
+
+# Arguments for the source repos 
+ARG O3DE_REPO=https://github.com/o3de/o3de.git
+ARG O3DE_BRANCH=development
+
+ARG O3DE_EXTRAS_REPO=https://github.com/o3de/o3de-extras.git
+ARG O3DE_EXTRAS_BRANCH=development
+
+ARG ROSCON_DEMO_REPO=https://github.com/o3de/ROSConDemo.git
+ARG ROSCON_DEMO_BRANCH=main
+
+# Additional argument to control build concurrency
+ARG CMAKE_JOBS=8
 ARG DEBIAN_FRONTEND=noninteractive
+
+ENV WORKSPACE=/data/workspace
+
+WORKDIR $WORKSPACE
+
+# Verify only the supported ROS2 versions was specified
+RUN if [ "${ROS_VERSION}" = "humble" ]; then \
+        echo "Building ROS2/Humble based image"; \
+    elif [ "${ROS_VERSION}" = "galactic" ]; then \
+        echo "Building ROS2/Galactic based image"; \
+    else \
+        echo "Unsupported ROS_VERSION: ${ROS_VERSION}" && exit 1; \
+    fi
 
 # Setup time zone and locale data (necessary for SSL and HTTPS packages)
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y \
@@ -17,16 +49,14 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y \
     tzdata \
     locales \
     keyboard-configuration \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && dpkg-reconfigure --frontend=noninteractive locales \
-    && update-locale LANG=en_US.UTF-8
+    && update-locale LANG=en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANG=en_US.UTF-8
 
-# Install common tools
-# deps in https://github.com/o3de/o3de/blob/development/scripts/build/build_node/Platform/Linux/package-list.ubuntu-jammy.txt
+# Install the required ubuntu packages
 RUN apt-get update && apt-get install -y \
     bc \
     bind9-utils \
@@ -34,6 +64,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     clang \
     cmake \
+    curl \
     file \
     firewalld \
     git \
@@ -70,81 +101,149 @@ RUN apt-get update && apt-get install -y \
     xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# Gem + ROSConDemo ROS pacakges
+# Setup and install the ROS packages
+RUN sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list' \
+    && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add - 
+
 RUN apt-get update && apt-get install -y \
-    ros-humble-ackermann-msgs \
-    ros-humble-control-toolbox \
-    ros-humble-gazebo-msgs \
-    ros-humble-joy \
-    ros-humble-navigation2 \
-    ros-humble-rviz2 \
-    ros-humble-tf2-ros \
-    ros-humble-urdfdom \
-    ros-humble-vision-msgs \
-    && rm -rf /var/lib/apt/lists/*
-
-## Symlink clang version to non-versioned clang and set cc to clang
-RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100 \
-    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
-
-# Assumes a local checkout of private ROSConDemo
-RUN git clone https://github.com/o3de/ROSConDemo.git \
-    && cd ROSConDemo \
-    && git lfs install \
-    && git lfs pull
-
-# Install o3de
-RUN git clone https://github.com/o3de/o3de.git -b development \
-    && cd o3de \
-    && git lfs install \
-    && git lfs pull \
-    && python/get_python.sh
-
-RUN git clone https://github.com/o3de/o3de-extras.git -b development
-
-RUN ./o3de/scripts/o3de.sh register --this-engine \
-    && ./o3de/scripts/o3de.sh register --gem-path ./o3de-extras/Gems/ROS2 \
-    && ./o3de/scripts/o3de.sh register -pp ./ROSConDemo/Project \
-    && ./o3de/scripts/o3de.sh enable-gem -gn ROS2 -pp ./ROSConDemo/Project \
-    && cat /root/.o3de/o3de_manifest.json
-
-WORKDIR $WORKDIR/ROSConDemo/Project
-
-RUN git lfs pull \
-    && . /opt/ros/humble/setup.sh \
-    && cmake -B build/linux -S . -G "Ninja Multi-Config" -DLY_DISABLE_TEST_MODULES=ON -DLY_STRIP_DEBUG_SYMBOLS=ON
-
-RUN . /opt/ros/humble/setup.sh \
-    && cmake --build build/linux --config profile --target ROSConDemo Editor AssetProcessor
-
-# This final step takes long since they Assets will be downloading
-RUN . /opt/ros/humble/setup.sh \
-    && echo "This final step can take more than 1 hour. Good time for going for a coffee :)" \
-    && cmake --build build/linux --config profile --target ROSConDemo.Assets
-
-# Installing o3de_kraken_nav
-RUN apt-get update && apt-get install -y \
+    ros-${ROS_DISTRO}-ackermann-msgs \
+    ros-${ROS_DISTRO}-control-toolbox \
+    ros-${ROS_DISTRO}-gazebo-msgs \
+    ros-${ROS_DISTRO}-joy \
+    ros-${ROS_DISTRO}-navigation2 \
+    ros-${ROS_DISTRO}-rviz2 \
+    ros-${ROS_DISTRO}-tf2-ros \
+    ros-${ROS_DISTRO}-urdfdom \
+    ros-${ROS_DISTRO}-vision-msgs \
     python3-colcon-common-extensions \
-    ros-humble-cyclonedds \
-    ros-humble-rmw-cyclonedds-cpp \
-    ros-humble-slam-toolbox \
-    ros-humble-navigation2 \
-    ros-humble-nav2-bringup \
-    ros-humble-pointcloud-to-laserscan \
-    ros-humble-teleop-twist-keyboard \
-    ros-humble-ackermann-msgs \
-    ros-humble-topic-tools \
-    && rm -rf /var/lib/apt/lists/*
+    ros-${ROS_DISTRO}-cyclonedds \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+    ros-${ROS_DISTRO}-slam-toolbox \
+    ros-${ROS_DISTRO}-navigation2 \
+    ros-${ROS_DISTRO}-nav2-bringup \
+    ros-${ROS_DISTRO}-pointcloud-to-laserscan \
+    ros-${ROS_DISTRO}-teleop-twist-keyboard \
+    ros-${ROS_DISTRO}-ackermann-msgs \
+    ros-${ROS_DISTRO}-topic-tools \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install python-statemachine
 
-RUN pip install python-statemachine
-
-WORKDIR $WORKDIR
-
-RUN mkdir -p o3de_kraken_ws/src \
-    && cd o3de_kraken_ws/src \
-    && ln -s $WORKDIR/ROSConDemo/kraken_nav kraken_nav
-
-RUN cd o3de_kraken_ws \
-    && colcon build --symlink-install
+# Depending on the image type, sync, setup and build only whats needed
+RUN if [ "${IMAGE_TYPE}" = "full" ]; then \
+        git clone --recursive $O3DE_REPO $WORKSPACE/o3de \
+        && git -C $WORKSPACE/o3de checkout $O3DE_BRANCH \
+        && git -C $WORKSPACE/o3de lfs install \
+        && git -C $WORKSPACE/o3de lfs pull \
+        && $WORKSPACE/o3de/python/get_python.sh \
+        && $WORKSPACE/o3de/scripts/o3de.sh register -ep $WORKSPACE/o3de \
+        && git clone $O3DE_EXTRAS_REPO \
+        && git -C $WORKSPACE/o3de-extras checkout $O3DE_EXTRAS_BRANCH \
+        && $WORKSPACE/o3de/scripts/o3de.sh register -gp $WORKSPACE/o3de-extras/Gems/ROS2 \
+        && git clone $ROSCON_DEMO_REPO \
+        && git -C $WORKSPACE/ROSConDemo checkout $ROSCON_DEMO_BRANCH \
+        && git -C $WORKSPACE/ROSConDemo lfs install \
+        && git -C $WORKSPACE/ROSConDemo lfs pull \
+        && $WORKSPACE/o3de/scripts/o3de.sh register -pp $WORKSPACE/ROSConDemo/Project \
+        && . /opt/ros/humble/setup.sh \
+        && cd $WORKSPACE/ROSConDemo/Project \
+        && cmake -B $WORKSPACE/ROSConDemo/Project/build/linux -S . -G "Ninja Multi-Config" -DLY_DISABLE_TEST_MODULES=ON -DLY_STRIP_DEBUG_SYMBOLS=ON \
+        && cmake --build $WORKSPACE/ROSConDemo/Project/build/linux --config profile --target ROSConDemo.GameLauncher Editor ROSConDemo.Assets -j $CMAKE_JOBS \
+        && cd $WORKSPACE/ROSConDemo/kraken_nav \
+        && colcon build --symlink-install \
+        && rm -rf ~/.o3de/3rdParty/ \
+        && rm -rf $WORKSPACE/o3de/.git \
+        && rm -rf $WORKSPACE/o3de/AutomatedTesting \
+        && rm -rf $WORKSPACE/o3de/python/downloaded_packages \
+        && rm -rf $WORKSPACE/o3de/Code \
+        && rm -rf $WORKSPACE/o3de/Gems \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/Azcg/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/CMake \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/CMakeFiles/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/External/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/Testing/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/_deps/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/cmake \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/lib/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/o3de/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/packages/;  \ 
+    elif [ "${IMAGE_TYPE}" = "simulation" ]; then \
+        git clone --recursive $O3DE_REPO $WORKSPACE/o3de \
+        && git -C $WORKSPACE/o3de checkout $O3DE_BRANCH \
+        && git -C $WORKSPACE/o3de lfs install \
+        && git -C $WORKSPACE/o3de lfs pull \
+        && $WORKSPACE/o3de/python/get_python.sh \
+        && $WORKSPACE/o3de/scripts/o3de.sh register -ep $WORKSPACE/o3de \
+        && git clone $O3DE_EXTRAS_REPO \
+        && git -C $WORKSPACE/o3de-extras checkout $O3DE_EXTRAS_BRANCH \
+        && $WORKSPACE/o3de/scripts/o3de.sh register -gp $WORKSPACE/o3de-extras/Gems/ROS2 \
+        && git clone $ROSCON_DEMO_REPO \
+        && git -C $WORKSPACE/ROSConDemo checkout $ROSCON_DEMO_BRANCH \
+        && git -C $WORKSPACE/ROSConDemo lfs install \
+        && git -C $WORKSPACE/ROSConDemo lfs pull \
+        && $WORKSPACE/o3de/scripts/o3de.sh register -pp $WORKSPACE/ROSConDemo/Project \
+        && . /opt/ros/humble/setup.sh \
+        && cd $WORKSPACE/ROSConDemo/Project \
+        && cmake -B $WORKSPACE/ROSConDemo/Project/build/linux -S . -G "Ninja Multi-Config" -DLY_DISABLE_TEST_MODULES=ON -DLY_STRIP_DEBUG_SYMBOLS=ON \
+        && cmake --build $WORKSPACE/ROSConDemo/Project/build/linux --config profile --target ROSConDemo.GameLauncher ROSConDemo.Assets -j $CMAKE_JOBS \
+        && cd $WORKSPACE/ROSConDemo/kraken_nav \
+        && colcon build --symlink-install \
+        && rm -rf $WORKSPACE/o3de-extras/ \
+        && rm -rf ~/.o3de/3rdParty/ \
+        && rm -rf $WORKSPACE/o3de/.git \
+        && rm -rf $WORKSPACE/o3de/AutomatedTesting \
+        && rm -rf $WORKSPACE/o3de/python/downloaded_packages \
+        && rm -rf $WORKSPACE/o3de/Code \
+        && rm -rf $WORKSPACE/o3de/Gems \
+        && rm -rf $WORKSPACE/ROSConDemo/.git \
+        && rm -rf $WORKSPACE/ROSConDemo/Gem \
+        && rm -rf $WORKSPACE/ROSConDemo/Source \
+        && rm -rf $WORKSPACE/ROSConDemo/Levels \
+        && rm -rf $WORKSPACE/ROSConDemo/ReflectionProbes \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/Azcg/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/CMake \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/CMakeFiles/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/External/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/Testing/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/_deps/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/cmake \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/lib/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/o3de/ \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/packages/ \ 
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/bin/profile/*.Editor.so \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/bin/profile/EditorPlugins \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/bin/profile/Editor \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/bin/profile/AssetProcessor \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/bin/profile/AssetProcessorBatch \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/bin/profile/MaterialEditor \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/bin/profile/AssetBuilder \
+        && rm -rf $WORKSPACE/ROSConDemo/build/linux/bin/profile/MaterialCanvas; \
+    elif [  "${IMAGE_TYPE}" = "navstack" ]; then \
+        git clone $ROSCON_DEMO_REPO \
+        && git -C $WORKSPACE/ROSConDemo checkout $ROSCON_DEMO_BRANCH \
+        && git -C $WORKSPACE/ROSConDemo lfs install \
+        && git -C $WORKSPACE/ROSConDemo lfs pull \
+        && cd $WORKSPACE/ROSConDemo/kraken_nav \
+        && colcon build --symlink-install; \
+    else \
+        echo "Unsupported IMAGE_TYPE: ${IMAGE_TYPE}" && exit 1; \
+    fi
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+
+# Add the appropriate ros2 environment setup script to the system startup
+RUN echo "[Unit]" > /etc/systemd/system/setup_ros.service \
+    && echo "After=network.target" >> /etc/systemd/system/setup_ros.service \
+    && echo "" >> /etc/systemd/system/setup_ros.service \
+    && echo "[Service]" >> /etc/systemd/system/setup_ros.service \
+    && if [ "${ROS_VERSION}" = "humble" ]; then \
+         echo "ExecStart=/opt/ros/humble/setup.bash" >> /etc/systemd/system/setup_ros.service; \
+       elif [ "${ROS_VERSION}" = "galactic" ]; then \
+         echo "ExecStart=/opt/ros/galactic/setup.bash" >> /etc/systemd/system/setup_ros.service; \
+       fi \
+    && echo "" >> /etc/systemd/system/setup_ros.service \
+    && echo "[Install]" >> /etc/systemd/system/setup_ros.service \
+    && echo "WantedBy=default.target" >> /etc/systemd/system/setup_ros.service \
+    && echo "" >> /etc/systemd/system/setup_ros.service
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES all

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ARG ROS_VERSION
 ARG UBUNTU_VERSION
 
 # Argument to control the type of docker image to build
-ARG IMAGE_TYPE=simulation  # Default to 'simulation'
+ARG IMAGE_TYPE=full  # Default to 'full'
 
 # Arguments for the source repos 
 ARG O3DE_REPO=https://github.com/o3de/o3de.git
@@ -154,8 +154,6 @@ RUN if [ "${IMAGE_TYPE}" = "full" ]; then \
         && rm -rf $WORKSPACE/o3de/.git \
         && rm -rf $WORKSPACE/o3de/AutomatedTesting \
         && rm -rf $WORKSPACE/o3de/python/downloaded_packages \
-        && rm -rf $WORKSPACE/o3de/Code \
-        && rm -rf $WORKSPACE/o3de/Gems \
         && rm -rf $WORKSPACE/ROSConDemo/build/linux/Azcg/ \
         && rm -rf $WORKSPACE/ROSConDemo/build/linux/CMake \
         && rm -rf $WORKSPACE/ROSConDemo/build/linux/CMakeFiles/ \
@@ -185,8 +183,6 @@ RUN if [ "${IMAGE_TYPE}" = "full" ]; then \
         && cd $WORKSPACE/ROSConDemo/Project \
         && cmake -B $WORKSPACE/ROSConDemo/Project/build/linux -S . -G "Ninja Multi-Config" -DLY_DISABLE_TEST_MODULES=ON -DLY_STRIP_DEBUG_SYMBOLS=ON \
         && cmake --build $WORKSPACE/ROSConDemo/Project/build/linux --config profile --target ROSConDemo.GameLauncher ROSConDemo.Assets -j $CMAKE_JOBS \
-        && cd $WORKSPACE/ROSConDemo/kraken_nav \
-        && colcon build --symlink-install \
         && rm -rf $WORKSPACE/o3de-extras/ \
         && rm -rf ~/.o3de/3rdParty/ \
         && rm -rf $WORKSPACE/o3de/.git \
@@ -221,14 +217,17 @@ RUN if [ "${IMAGE_TYPE}" = "full" ]; then \
         git clone $ROSCON_DEMO_REPO \
         && git -C $WORKSPACE/ROSConDemo checkout $ROSCON_DEMO_BRANCH \
         && git -C $WORKSPACE/ROSConDemo lfs install \
-        && git -C $WORKSPACE/ROSConDemo lfs pull \
-        && cd $WORKSPACE/ROSConDemo/kraken_nav \
-        && colcon build --symlink-install; \
+        && git -C $WORKSPACE/ROSConDemo lfs pull; \
     else \
         echo "Unsupported IMAGE_TYPE: ${IMAGE_TYPE}" && exit 1; \
     fi
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+
+# Compile the navstack and add configuration to the startup
+RUN cd $WORKSPACE/ROSConDemo/kraken_nav \
+    && colcon build --symlink-install \
+    && echo "source /data/workspace/ROSConDemo/kraken_nav/install/setup.bash" >> ~/.bashrc
 
 # Add the appropriate ros2 environment setup script to the system startup
 RUN echo "[Unit]" > /etc/systemd/system/setup_ros.service \
@@ -244,6 +243,7 @@ RUN echo "[Unit]" > /etc/systemd/system/setup_ros.service \
     && echo "[Install]" >> /etc/systemd/system/setup_ros.service \
     && echo "WantedBy=default.target" >> /etc/systemd/system/setup_ros.service \
     && echo "" >> /etc/systemd/system/setup_ros.service
+
 
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES all

--- a/docker/README.md
+++ b/docker/README.md
@@ -99,7 +99,16 @@ A slimmer docker image can be built that only contains the ROSConDemo simulation
 The Dockerfile provides arguments to build docker images that only contain the necessary files to run the O3DE simulation launcher and the navigation stack, without the need to launch the O3DE Editor. To build the the docker image for just the simulation portion of the ROSConDemo, run the following command:
 
 ```
-docker build --build-arg IMAGE_TYPE=simulation --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg ROSCON_DEMO_BRANCH=development -t roscon_demo -f Dockerfile .
+docker build --build-arg IMAGE_TYPE=simulation --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg ROSCON_DEMO_BRANCH=development -t roscon_demo_simulation -f Dockerfile .
 ```
+
+## Creating a navigation stack only Docker Images.
+
+A minimal docker image that only contains the built ```kraken_nav``` navigation stack can also be specified. This is useful to have an image separate from the simulation environment to monitor and control the simulation through the ROS2 framework. The argument ```IMAGE_TYPE``` will need to be set to ```navstack``` to build this image. The image will be even smaller since it will not contain any O3DE simulation binaries or assets. It will have the necessary ROS2 packages including the rviz visualizer to view and control the simulation. To build the navigation stack only docker image, run the following command:
+
+```
+docker build --build-arg IMAGE_TYPE=navstack --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg ROSCON_DEMO_BRANCH=development -t roscon_demo_navstack -f Dockerfile .
+```
+
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Dockerfile for running the ROSConDemo
 
-The dockerfile defined in this path will prepare the appropiate ROS2 package (Ubuntu 20.04/Focal Galactic or Ubuntu 22.04/Jammy + Humble) based environment and build the components necessary to run the O3DE demo project simulator through the O3DE engine.
+The dockerfile defined in this path will prepare the appropiate ROS2 package (Ubuntu 20.04/Focal Galactic or Ubuntu 22.04/Jammy + Humble) based environment and build the components necessary to run the ROSCon demo project simulator through the O3DE engine.
 
 ## Prerequisites
 
@@ -18,14 +18,14 @@ The dockerfile supports defining which version of Ubuntu+ROS to base the docker 
 To build the docker image for the ROSConDemo environment, run the following command:
 
 ```
-docker build -t roscon_demo -f Dockerfile .
+docker build --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg ROSCON_DEMO_BRANCH=development -t roscon_demo -f Dockerfile .
 ```
 
 This will create a `roscon_demo` docker image which will used when running the container.
 
 
 **Note** 
-The above command example will build the full simulation environment needed to run the O3DE editor, O3DE simulation launcher, and the simulation navigation stack, based on the latest code from the o3de (O3DE Engine), o3de-extras (ROS2 Gem), and the ROSConDemo. Arguments are available to customize and fine-tune this process which is discussed below.
+The above command example will build the full simulation environment needed to run the O3DE editor, O3DE simulation launcher, and the simulation navigation stack, based on the latest code from the o3de (O3DE Engine), o3de-extras (ROS2 Gem), and the ROSConDemo. The arguments specified will pull in the last known good version of the dependent projects from their repo. Additional arguments are available to customize and fine-tune this process and is described below.
 
 The build process may take over two hours depending on the hardware resource and network connectivity of the machine used to build the image.
 
@@ -39,11 +39,6 @@ Another option is to install and use [rocker](https://github.com/osrf/rocker).
 rocker --x11 --nvidia roscon_demo
 ```
 
-To launch the rviz visualizer tool with the navigation stack, you will need to run the ```kraken_nav``` setup script first.
-
-```
-source /data/workspace/ROSConDemo/Project/kraken_nav/install/setup.bash
-```
 
 To launch the O3DE editor for the ROSConDemo project, execute the following command within the docker terminal
 
@@ -56,21 +51,10 @@ Further instructions and details can be found in the [main README file](https://
 To launch the O3DE simulation launcher for the ROSConDemo project, execute the following command within the docker terminal
 
 ```
-/data/workspace/ROSConDemo/Project/build/linux/bin/profile/./ROSConDemo.GameLauncher -bg_ConnectToAssetProcessor=0 -LoadLevel=main
+/data/workspace/ROSConDemo/Project/build/linux/bin/profile/./ROSConDemo.GameLauncher -LoadLevel=main
 ```
 
 To spawn or launch the rviz visualizer, follow the [kraken_nav README file](https://github.com/o3de/ROSConDemo/blob/development/kraken_nav/README.md#running-simulation)
-
-
-## Creating the Simulation only Docker Images.
-
-The Dockerfile provides arguments to build docker images that only contain the necessary files to run the O3DE simulation launcher and the navigation stack, without the need to launch the O3DE Editor. To build the the docker image for just the simulation portion of the ROSConDemo, run the following command:
-
-```
-docker build -t roscon_demo_simulation --build-arg IMAGE_TYPE=simulation -f Dockerfile . 
-```
-
-The resulting docker image ```roscon_demo_simulation``` will be a leaner image that does not the O3DE editor, only the items needed to launch the O3DE simulation for the ROSConDemo and the ```kraken_nav``` navigation stack.
 
 ## Advanced Options
 
@@ -107,7 +91,15 @@ In addition the repositories, the following arguments target the branch, commit,
 The docker script provides a cmake-specific argument override to control the number of parallel jobs that can be used during the build of the docker image. ```CMAKE_JOBS``` sets the maximum number of concurrent jobs cmake will run during its build process and defaults to 8 jobs. This number can be adjusted to better suit the hardware which is running the docker image build.
 
 
+## Creating the Simulation only Docker Images.
+
+A slimmer docker image can be built that only contains the ROSConDemo simulation launcher and the kraken_nav navigation stack. The O3DE editor will not be part of the image, and therefore will build will take less time and will take less space. The argument ```IMAGE_TYPE``` can be set to ```simulation``` to create this docker image.
+
+
+The Dockerfile provides arguments to build docker images that only contain the necessary files to run the O3DE simulation launcher and the navigation stack, without the need to launch the O3DE Editor. To build the the docker image for just the simulation portion of the ROSConDemo, run the following command:
+
 ```
-docker build --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg ROSCON_DEMO_BRANCH=development -t roscon_demo -f Dockerfile .
+docker build --build-arg IMAGE_TYPE=simulation --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg ROSCON_DEMO_BRANCH=development -t roscon_demo -f Dockerfile .
 ```
+
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,32 +1,37 @@
 # Dockerfile for running the ROSConDemo
 
-The Dockerfile is going to create an Ubuntu Jammy + ROS Humble platform
-that prepares the O3DE simulator together with the o3de-ros2-gem to run
-the demo in this repository.
+The dockerfile defined in this path will prepare the appropiate ROS2 package (Ubuntu 20.04/Focal Galactic or Ubuntu 22.04/Jammy + Humble) based environment and build the components necessary to run the O3DE demo project simulator through the O3DE engine.
 
-## Requisites
+## Prerequisites
 
- * [Hardware requirements of o3de](https://www.o3de.org/docs/welcome-guide/requirements/)
- * At least 40GB of free disk space
- * The build process can take more than 2 hours
+* [Hardware requirements of o3de](https://www.o3de.org/docs/welcome-guide/requirements/)
+* Ubuntu 20.04 (Focal) or 22.04 (Jammy)
+* At least 60 GB of free disk space
+* Docker installed and configured
+  * **Note** It is recommended to have Docker installed correctly and in a secure manner so that the docker commands in this guide do not require elevated priviledges (sudo) in order to run them. See [Docker Engine post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) for more details.
+* [NVidia container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 
 ## Building the Docker Image
 
-To build the Dockerfile the only required step is to clone first the ROSConDemo:
+The dockerfile supports defining which version of Ubuntu+ROS to base the docker container on, and by default will support Ubuntu 22.04 (jammy) with the ROS2 Humber distribution. It will build an O3DE simulation environment that is configured to launch the O3DE editor, O3DE simulation launcher, and the simulation navigation stack used for the simulation.
+
+To build the docker image for the ROSConDemo environment, run the following command:
+
 ```
-git clone https://github.com/o3de/ROSConDemo.git
-cd ROSConDemo/docker
 docker build -t roscon_demo -f Dockerfile .
 ```
 
-Note: the build process is going to download all the necessary assets for running
-the demo so it can take several hours depending on the Internet connection.
+This will create a `roscon_demo` docker image which will used when running the container.
+
+
+**Note** 
+The above command example will build the full simulation environment needed to run the O3DE editor, O3DE simulation launcher, and the simulation navigation stack, based on the latest code from the o3de (O3DE Engine), o3de-extras (ROS2 Gem), and the ROSConDemo. Arguments are available to customize and fine-tune this process which is discussed below.
+
+The build process may take over two hours depending on the hardware resource and network connectivity of the machine used to build the image.
 
 ## Running the Docker Image
 
-GPU acceleration is required for running O3DE correctly. For running docker
-with support for GPU please follow the documentation for
-[docker run](https://docs.docker.com/engine/reference/commandline/run/).
+GPU acceleration is required for running O3DE correctly. For running docker with support for GPU please follow the documentation for [docker run](https://docs.docker.com/engine/reference/commandline/run/).
 
 Another option is to install and use [rocker](https://github.com/osrf/rocker).
 
@@ -34,11 +39,75 @@ Another option is to install and use [rocker](https://github.com/osrf/rocker).
 rocker --x11 --nvidia roscon_demo
 ```
 
-The `Dockerfile` leaves ready the compilation of all the O3DE artifacts to be able
-to execute the Editor.
+To launch the rviz visualizer tool with the navigation stack, you will need to run the ```kraken_nav``` setup script first.
+
+```
+source /data/workspace/ROSConDemo/Project/kraken_nav/install/setup.bash
+```
+
+To launch the O3DE editor for the ROSConDemo project, execute the following command within the docker terminal
+
 ```
 /data/workspace/ROSConDemo/Project/build/linux/bin/profile/Editor
 ```
 
-Continue with the instruction in the
-[main README file](https://github.com/o3de/ROSConDemo/blob/main/README.md).
+Further instructions and details can be found in the [main README file](https://github.com/o3de/ROSConDemo/blob/development/README.md#running-the-demo-scenario)
+
+To launch the O3DE simulation launcher for the ROSConDemo project, execute the following command within the docker terminal
+
+```
+/data/workspace/ROSConDemo/Project/build/linux/bin/profile/./ROSConDemo.GameLauncher -bg_ConnectToAssetProcessor=0 -LoadLevel=main
+```
+
+To spawn or launch the rviz visualizer, follow the [kraken_nav README file](https://github.com/o3de/ROSConDemo/blob/development/kraken_nav/README.md#running-simulation)
+
+
+## Creating the Simulation only Docker Images.
+
+The Dockerfile provides arguments to build docker images that only contain the necessary files to run the O3DE simulation launcher and the navigation stack, without the need to launch the O3DE Editor. To build the the docker image for just the simulation portion of the ROSConDemo, run the following command:
+
+```
+docker build -t roscon_demo_simulation --build-arg IMAGE_TYPE=simulation -f Dockerfile . 
+```
+
+The resulting docker image ```roscon_demo_simulation``` will be a leaner image that does not the O3DE editor, only the items needed to launch the O3DE simulation for the ROSConDemo and the ```kraken_nav``` navigation stack.
+
+## Advanced Options
+
+### Target ROS2 Distribution
+The Docker script defaults to building an image based on Ubuntu 20.04 (bionic) and the ROS2 Humble distribution. This can be overridden 
+with a combination if the ```ROS_VERSION``` and ```UBUNTU_VERSION``` arguments.
+
+| ROS2 Distro   | Repository                                |
+|---------------|-------------------------------------------|
+| galactic      | ROS_VERSION=galactic UBUNTU_VERSION=focal |
+| humble        | ROS_VERSION=humble UBUNTU_VERSION=humble  |
+
+
+### Custom source repos and branches
+
+The Dockerscripts use the following arguments to determine the repository to pull the source from. 
+
+| Argument              | Repository                       | Default     |
+|-----------------------|----------------------------------|-------------|
+| O3DE_REPO             | O3DE                             | https://github.com/o3de/o3de.git                   |
+| O3DE_EXTRAS_REPO      | O3DE Extras                      | https://github.com/o3de/o3de-extras.git            |
+| ROSCON_DEMO_REPO      | ROSConDemo repository            | https://github.com/o3de/RobotVacuumSample          |
+
+
+In addition the repositories, the following arguments target the branch, commit, or tag to pull from their corresponding repository
+
+| Argument                | Repository                       | Default     |
+|-------------------------|----------------------------------|-------------|
+| O3DE_BRANCH             | O3DE                             | development |
+| O3DE_EXTRAS_BRANCH      | O3DE Extras                      | development |
+| ROSCON_DEMO_BRANCH      | ROSConDemo repository            | main        |
+
+### Optimizing the build process ###
+The docker script provides a cmake-specific argument override to control the number of parallel jobs that can be used during the build of the docker image. ```CMAKE_JOBS``` sets the maximum number of concurrent jobs cmake will run during its build process and defaults to 8 jobs. This number can be adjusted to better suit the hardware which is running the docker image build.
+
+
+```
+docker build --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg ROSCON_DEMO_BRANCH=development -t roscon_demo -f Dockerfile .
+```
+


### PR DESCRIPTION

Updates to Dockerscript for the ROSConDemo

* Add additional arguments to optionally control the repo and branch for the project sources that the Dockerscript relies on. 
* Updated the README example to point to the last known version that works for the demo
* Add argument ```CMAKE_JOBS``` to control the number of parallel build jobs to optionally fine-tune the docker build. Default to 8.
* Add additional argument (ROS_VERSION) to optionally choose 'galactic' or 'humble'. Default to humble.
* Add additional argument (UBUNTU_VERSION) to optionally choose the base Ubuntu environment. Default to jammy
* Compressed common docker RUNS together to optimize the final docker image size
* Add additional argument (IMAGE_TYPE) to control the type of docker image to build: ```full``` (default), ```simulation```, and ```navstack```. Default to 
  * ```full``` (default), 
  * ```simulation```
  * ```navstack```
* Add additional commands to cleanup intermediate and unnecessary files that are not needed by runtime as part of the sync and build run commands.
* Integrated ROS2 setup command into an /etc/systemd system call to initialize on docker container startup
* Added call to the navstack setup script in ~/bash.rc 
* Added details to the README to describe the docker installation prerequisites, including guides on how to setup docker to run without sudo, and setting up docker for nvidia
* Update disk space requirements


The docker and readme was tested using the following commands:

**Building the full ROSConDemo Docker**
```
docker build --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg ROSCON_DEMO_BRANCH=development --build-arg CMAKE_JOBS=32 -t roscon_demo -f Dockerfile .
```
*Launching the full ROSConDemo Docker*
```
rocker --x11 --nvidia roscon_demo
```

*Launching the Editor within the full ROSCon Docker*
After the full ROSConDemo docker is launched:
```
/data/workspace/ROSConDemo/Project/build/linux/bin/profile/Editor
```

*Launching the ROSConDemo simulation launcher within the full ROSConDemo Docker*
After exiting the Editor from the above run, go back to the terminal and run :
```
/data/workspace/ROSConDemo/Project/build/linux/bin/profile/ROSConDemo.GameLauncher -LoadLevel=main
```

*Spawning a kraken and launching rviz through another full  ROSConDemo Docker image*
After launching another full ROSConDemo docker in a new terminal (same command):
```
ros2 service call /spawn_entity gazebo_msgs/srv/SpawnEntity '{name: 'apple_kraken_rusty', xml: 'line1'}'

ros2 launch o3de_kraken_nav navigation_multi.launch.py namespace:=apple_kraken_rusty_1 rviz:=True
```

fixes https://github.com/o3de/ROSConDemo/issues/214
fixes https://github.com/o3de/ROSConDemo/issues/212




