### PR TITLE
Docker remove galactic option

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -218,7 +218,7 @@ RUN echo "[Unit]" > /etc/systemd/system/setup_ros.service \
     && echo "After=network.target" >> /etc/systemd/system/setup_ros.service \
     && echo "" >> /etc/systemd/system/setup_ros.service \
     && echo "[Service]" >> /etc/systemd/system/setup_ros.service \
-    && echo "ExecStart=/opt/ros/humble/setup.bash" >> /etc/systemd/system/setup_ros.service; \
+    && echo "ExecStart=/opt/ros/humble/setup.bash" >> /etc/systemd/system/setup_ros.service \
     && echo "" >> /etc/systemd/system/setup_ros.service \
     && echo "[Install]" >> /etc/systemd/system/setup_ros.service \
     && echo "WantedBy=default.target" >> /etc/systemd/system/setup_ros.service \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,25 +90,25 @@ RUN sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_re
     && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add - 
 
 RUN apt-get update && apt-get install -y \
-    ros-humble-ackermann-msgs \
-    ros-humble-control-toolbox \
-    ros-humble-gazebo-msgs \
-    ros-humble-joy \
-    ros-humble-navigation2 \
-    ros-humble-rviz2 \
-    ros-humble-tf2-ros \
-    ros-humble-urdfdom \
-    ros-humble-vision-msgs \
+    ros-${ROS_DISTRO}-ackermann-msgs \
+    ros-${ROS_DISTRO}-control-toolbox \
+    ros-${ROS_DISTRO}-gazebo-msgs \
+    ros-${ROS_DISTRO}-joy \
+    ros-${ROS_DISTRO}-navigation2 \
+    ros-${ROS_DISTRO}-rviz2 \
+    ros-${ROS_DISTRO}-tf2-ros \
+    ros-${ROS_DISTRO}-urdfdom \
+    ros-${ROS_DISTRO}-vision-msgs \
     python3-colcon-common-extensions \
-    ros-humble-cyclonedds \
-    ros-humble-rmw-cyclonedds-cpp \
-    ros-humble-slam-toolbox \
-    ros-humble-navigation2 \
-    ros-humble-nav2-bringup \
-    ros-humble-pointcloud-to-laserscan \
-    ros-humble-teleop-twist-keyboard \
-    ros-humble-ackermann-msgs \
-    ros-humble-topic-tools \
+    ros-${ROS_DISTRO}-cyclonedds \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+    ros-${ROS_DISTRO}-slam-toolbox \
+    ros-${ROS_DISTRO}-navigation2 \
+    ros-${ROS_DISTRO}-nav2-bringup \
+    ros-${ROS_DISTRO}-pointcloud-to-laserscan \
+    ros-${ROS_DISTRO}-teleop-twist-keyboard \
+    ros-${ROS_DISTRO}-ackermann-msgs \
+    ros-${ROS_DISTRO}-topic-tools \
     && rm -rf /var/lib/apt/lists/* \
     && pip install python-statemachine
 
@@ -128,7 +128,7 @@ RUN if [ "${IMAGE_TYPE}" = "full" ]; then \
         && git -C $WORKSPACE/ROSConDemo lfs install \
         && git -C $WORKSPACE/ROSConDemo lfs pull \
         && $WORKSPACE/o3de/scripts/o3de.sh register -pp $WORKSPACE/ROSConDemo/Project \
-        && . /opt/ros/humble/setup.sh \
+        && . /opt/ros/${ROS_DISTRO}/setup.sh \
         && cd $WORKSPACE/ROSConDemo/Project \
         && cmake -B $WORKSPACE/ROSConDemo/Project/build/linux -S . -G "Ninja Multi-Config" -DLY_DISABLE_TEST_MODULES=ON -DLY_STRIP_DEBUG_SYMBOLS=ON \
         && cmake --build $WORKSPACE/ROSConDemo/Project/build/linux --config profile --target ROSConDemo.GameLauncher Editor ROSConDemo.Assets -j $CMAKE_JOBS \
@@ -163,7 +163,7 @@ RUN if [ "${IMAGE_TYPE}" = "full" ]; then \
         && git -C $WORKSPACE/ROSConDemo lfs install \
         && git -C $WORKSPACE/ROSConDemo lfs pull \
         && $WORKSPACE/o3de/scripts/o3de.sh register -pp $WORKSPACE/ROSConDemo/Project \
-        && . /opt/ros/humble/setup.sh \
+        && . /opt/ros/${ROS_DISTRO}/setup.sh \
         && cd $WORKSPACE/ROSConDemo/Project \
         && cmake -B $WORKSPACE/ROSConDemo/Project/build/linux -S . -G "Ninja Multi-Config" -DLY_DISABLE_TEST_MODULES=ON -DLY_STRIP_DEBUG_SYMBOLS=ON \
         && cmake --build $WORKSPACE/ROSConDemo/Project/build/linux --config profile --target ROSConDemo.GameLauncher ROSConDemo.Assets -j $CMAKE_JOBS \
@@ -218,12 +218,16 @@ RUN echo "[Unit]" > /etc/systemd/system/setup_ros.service \
     && echo "After=network.target" >> /etc/systemd/system/setup_ros.service \
     && echo "" >> /etc/systemd/system/setup_ros.service \
     && echo "[Service]" >> /etc/systemd/system/setup_ros.service \
-    && echo "ExecStart=/opt/ros/humble/setup.bash" >> /etc/systemd/system/setup_ros.service \
+    && if [ "${ROS_DISTRO}" = "humble" ]; then \
+         echo "ExecStart=/opt/ros/humble/setup.bash" >> /etc/systemd/system/setup_ros.service; \
+       elif [ "${ROS_DISTRO}" = "galactic" ]; then \
+         echo "ExecStart=/opt/ros/galactic/setup.bash" >> /etc/systemd/system/setup_ros.service; \
+       fi \
     && echo "" >> /etc/systemd/system/setup_ros.service \
     && echo "[Install]" >> /etc/systemd/system/setup_ros.service \
     && echo "WantedBy=default.target" >> /etc/systemd/system/setup_ros.service \
     && echo "" >> /etc/systemd/system/setup_ros.service
 
-
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES all
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,14 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 
-# Collect the arguments for the base ros image
-ARG ROS_VERSION=humble
-ARG UBUNTU_VERSION=jammy
-
-FROM ros:${ROS_VERSION}-ros-base-${UBUNTU_VERSION}
-
-ARG ROS_VERSION
-ARG UBUNTU_VERSION
+FROM ros:humble-ros-base-jammy
 
 # Argument to control the type of docker image to build
 ARG IMAGE_TYPE=full  # Default to 'full'
@@ -33,15 +26,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV WORKSPACE=/data/workspace
 
 WORKDIR $WORKSPACE
-
-# Verify only the supported ROS2 versions was specified
-RUN if [ "${ROS_VERSION}" = "humble" ]; then \
-        echo "Building ROS2/Humble based image"; \
-    elif [ "${ROS_VERSION}" = "galactic" ]; then \
-        echo "Building ROS2/Galactic based image"; \
-    else \
-        echo "Unsupported ROS_VERSION: ${ROS_VERSION}" && exit 1; \
-    fi
 
 # Setup time zone and locale data (necessary for SSL and HTTPS packages)
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y \
@@ -106,25 +90,25 @@ RUN sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_re
     && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add - 
 
 RUN apt-get update && apt-get install -y \
-    ros-${ROS_DISTRO}-ackermann-msgs \
-    ros-${ROS_DISTRO}-control-toolbox \
-    ros-${ROS_DISTRO}-gazebo-msgs \
-    ros-${ROS_DISTRO}-joy \
-    ros-${ROS_DISTRO}-navigation2 \
-    ros-${ROS_DISTRO}-rviz2 \
-    ros-${ROS_DISTRO}-tf2-ros \
-    ros-${ROS_DISTRO}-urdfdom \
-    ros-${ROS_DISTRO}-vision-msgs \
+    ros-humble-ackermann-msgs \
+    ros-humble-control-toolbox \
+    ros-humble-gazebo-msgs \
+    ros-humble-joy \
+    ros-humble-navigation2 \
+    ros-humble-rviz2 \
+    ros-humble-tf2-ros \
+    ros-humble-urdfdom \
+    ros-humble-vision-msgs \
     python3-colcon-common-extensions \
-    ros-${ROS_DISTRO}-cyclonedds \
-    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
-    ros-${ROS_DISTRO}-slam-toolbox \
-    ros-${ROS_DISTRO}-navigation2 \
-    ros-${ROS_DISTRO}-nav2-bringup \
-    ros-${ROS_DISTRO}-pointcloud-to-laserscan \
-    ros-${ROS_DISTRO}-teleop-twist-keyboard \
-    ros-${ROS_DISTRO}-ackermann-msgs \
-    ros-${ROS_DISTRO}-topic-tools \
+    ros-humble-cyclonedds \
+    ros-humble-rmw-cyclonedds-cpp \
+    ros-humble-slam-toolbox \
+    ros-humble-navigation2 \
+    ros-humble-nav2-bringup \
+    ros-humble-pointcloud-to-laserscan \
+    ros-humble-teleop-twist-keyboard \
+    ros-humble-ackermann-msgs \
+    ros-humble-topic-tools \
     && rm -rf /var/lib/apt/lists/* \
     && pip install python-statemachine
 
@@ -144,7 +128,7 @@ RUN if [ "${IMAGE_TYPE}" = "full" ]; then \
         && git -C $WORKSPACE/ROSConDemo lfs install \
         && git -C $WORKSPACE/ROSConDemo lfs pull \
         && $WORKSPACE/o3de/scripts/o3de.sh register -pp $WORKSPACE/ROSConDemo/Project \
-        && . /opt/ros/${ROS_DISTRO}/setup.sh \
+        && . /opt/ros/humble/setup.sh \
         && cd $WORKSPACE/ROSConDemo/Project \
         && cmake -B $WORKSPACE/ROSConDemo/Project/build/linux -S . -G "Ninja Multi-Config" -DLY_DISABLE_TEST_MODULES=ON -DLY_STRIP_DEBUG_SYMBOLS=ON \
         && cmake --build $WORKSPACE/ROSConDemo/Project/build/linux --config profile --target ROSConDemo.GameLauncher Editor ROSConDemo.Assets -j $CMAKE_JOBS \
@@ -179,7 +163,7 @@ RUN if [ "${IMAGE_TYPE}" = "full" ]; then \
         && git -C $WORKSPACE/ROSConDemo lfs install \
         && git -C $WORKSPACE/ROSConDemo lfs pull \
         && $WORKSPACE/o3de/scripts/o3de.sh register -pp $WORKSPACE/ROSConDemo/Project \
-        && . /opt/ros/${ROS_DISTRO}/setup.sh \
+        && . /opt/ros/humble/setup.sh \
         && cd $WORKSPACE/ROSConDemo/Project \
         && cmake -B $WORKSPACE/ROSConDemo/Project/build/linux -S . -G "Ninja Multi-Config" -DLY_DISABLE_TEST_MODULES=ON -DLY_STRIP_DEBUG_SYMBOLS=ON \
         && cmake --build $WORKSPACE/ROSConDemo/Project/build/linux --config profile --target ROSConDemo.GameLauncher ROSConDemo.Assets -j $CMAKE_JOBS \
@@ -234,11 +218,7 @@ RUN echo "[Unit]" > /etc/systemd/system/setup_ros.service \
     && echo "After=network.target" >> /etc/systemd/system/setup_ros.service \
     && echo "" >> /etc/systemd/system/setup_ros.service \
     && echo "[Service]" >> /etc/systemd/system/setup_ros.service \
-    && if [ "${ROS_VERSION}" = "humble" ]; then \
-         echo "ExecStart=/opt/ros/humble/setup.bash" >> /etc/systemd/system/setup_ros.service; \
-       elif [ "${ROS_VERSION}" = "galactic" ]; then \
-         echo "ExecStart=/opt/ros/galactic/setup.bash" >> /etc/systemd/system/setup_ros.service; \
-       fi \
+    && echo "ExecStart=/opt/ros/humble/setup.bash" >> /etc/systemd/system/setup_ros.service; \
     && echo "" >> /etc/systemd/system/setup_ros.service \
     && echo "[Install]" >> /etc/systemd/system/setup_ros.service \
     && echo "WantedBy=default.target" >> /etc/systemd/system/setup_ros.service \

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ The dockerfile supports defining which version of Ubuntu+ROS to base the docker 
 To build the docker image for the ROSConDemo environment, run the following command:
 
 ```
-docker build --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg -t roscon_demo -f Dockerfile .
+docker build --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 -t roscon_demo -f Dockerfile .
 ```
 
 This will create a `roscon_demo` docker image which will used when running the container.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Dockerfile for running the ROSConDemo
 
-The dockerfile defined in this path will prepare the appropiate ROS2 package (Ubuntu 20.04/Focal Galactic or Ubuntu 22.04/Jammy + Humble) based environment and build the components necessary to run the ROSCon demo project simulator through the O3DE engine.
+The dockerfile defined in this path will prepare the appropiate ROS2 Humble distribution based environment and build the components necessary to run the ROSCon demo project simulator through the O3DE engine.
 
 ## Prerequisites
 
@@ -57,16 +57,6 @@ To launch the O3DE simulation launcher for the ROSConDemo project, execute the f
 To spawn or launch the rviz visualizer, follow the [kraken_nav README file](https://github.com/o3de/ROSConDemo/blob/development/kraken_nav/README.md#running-simulation)
 
 ## Advanced Options
-### Target ROS2 Distribution
-The Docker script defaults to building an image based on Ubuntu 22.04 (jammy) and the ROS2 Humble distribution. This can be overridden 
-with a combination if the `ROS_VERSION` and `UBUNTU_VERSION` arguments.
-
-| ROS2 Distro   | Repository                                |
-|---------------|-------------------------------------------|
-| galactic      | ROS_VERSION=galactic UBUNTU_VERSION=focal |
-| humble        | ROS_VERSION=humble UBUNTU_VERSION=jammy   |
-
-
 ### Custom source repos and branches
 
 The Dockerscripts use the following arguments to determine the repository to pull the source from. 

--- a/docker/README.md
+++ b/docker/README.md
@@ -88,7 +88,7 @@ A slimmer docker image can be built that only contains the ROSConDemo simulation
 The Dockerfile provides arguments to build docker images that only contain the necessary files to run the O3DE simulation launcher and the navigation stack, without the need to launch the O3DE Editor. To build the the docker image for just the simulation portion of the ROSConDemo, run the following command:
 
 ```
-docker build --build-arg IMAGE_TYPE=simulation --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg ROSCON_DEMO_BRANCH=development -t roscon_demo_simulation -f Dockerfile .
+docker build --build-arg IMAGE_TYPE=simulation --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 -t roscon_demo_simulation -f Dockerfile .
 ```
 
 ## Creating a navigation stack only Docker Images.

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ The dockerfile supports defining which version of Ubuntu+ROS to base the docker 
 To build the docker image for the ROSConDemo environment, run the following command:
 
 ```
-docker build --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg ROSCON_DEMO_BRANCH=development -t roscon_demo -f Dockerfile .
+docker build --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg -t roscon_demo -f Dockerfile .
 ```
 
 This will create a `roscon_demo` docker image which will used when running the container.


### PR DESCRIPTION
Removing option to override the ROS2 distribution to use `galactic` and fix it to use `humble` since:
* Does not work properly with galactic
* No real value demonstrating compatibility with galactic especially since its reached end of life anyways
* You can still run a ubuntu 22.04 based docker image on ubuntu 20.04 anyways

Also removing the build-arg to specify `development` branch for ROSCon since its the default now in the Dockerfile