### PR TITLE
Updated colliders in prefabs by running 'ed_physxUpdatePrefabsWithColliderComponents' command

### DIFF
--- a/Project/Assets/Kraken/apple_kraken_v1/apple_kraken_v1.prefab
+++ b/Project/Assets/Kraken/apple_kraken_v1/apple_kraken_v1.prefab
@@ -3494,7 +3494,7 @@
                     "Id": 13177781661023720894
                 },
                 "Component_[14535670656735835043]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14535670656735835043,
                     "ColliderConfiguration": {
                         "CollisionLayer": {

--- a/Project/Assets/Kraken/apple_kraken_v2/apple_kraken_v2.prefab
+++ b/Project/Assets/Kraken/apple_kraken_v2/apple_kraken_v2.prefab
@@ -4246,7 +4246,7 @@
                     "Id": 13177781661023720894
                 },
                 "Component_[14535670656735835043]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14535670656735835043,
                     "ColliderConfiguration": {
                         "CollisionLayer": {

--- a/Project/Prefabs/Barn.prefab
+++ b/Project/Prefabs/Barn.prefab
@@ -90,7 +90,7 @@
                     "Id": 15710930892613769566
                 },
                 "Component_[15791848428761537412]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15791848428761537412,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Project/Prefabs/Barrel.prefab
+++ b/Project/Prefabs/Barrel.prefab
@@ -99,7 +99,7 @@
                     "Id": 13073289245211694411
                 },
                 "Component_[14322969105034715544]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14322969105034715544,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Project/Prefabs/Crate.prefab
+++ b/Project/Prefabs/Crate.prefab
@@ -112,7 +112,7 @@
                     "Id": 15825972752429895097
                 },
                 "Component_[3012283993462436523]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3012283993462436523,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Project/Prefabs/LidarKraken.prefab
+++ b/Project/Prefabs/LidarKraken.prefab
@@ -82,7 +82,7 @@
                     "Id": 14073014337522366363
                 },
                 "Component_[14535670656735835043]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14535670656735835043,
                     "ColliderConfiguration": {
                         "CollisionGroupId": {

--- a/Project/Prefabs/WagonWheel.prefab
+++ b/Project/Prefabs/WagonWheel.prefab
@@ -162,7 +162,7 @@
                     "Id": 9683050697670722667
                 },
                 "Component_[9744507723268008838]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 9744507723268008838,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Project/Prefabs/WaterTower.prefab
+++ b/Project/Prefabs/WaterTower.prefab
@@ -87,7 +87,7 @@
                     "Id": 13792841411106827297
                 },
                 "Component_[13912151555249104113]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 13912151555249104113,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Project/Prefabs/WindMill.prefab
+++ b/Project/Prefabs/WindMill.prefab
@@ -113,7 +113,7 @@
                     ]
                 },
                 "Component_[16842351070526488773]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 16842351070526488773,
                     "ColliderConfiguration": {
                         "MaterialSlots": {


### PR DESCRIPTION
Note
This is part of the work to separate PhysX Collider into 2 components: https://github.com/o3de/o3de/pull/14725.
This is currently as draft to avoid submitting it too early.

Reviewers
Please review and approve this draft and once the main change is submitted into o3de I will merge this as well.

Testing
All converted prefabs were processed successfully by the Asset Processor.
Opened the Main level in the editor without errors. Manually checked a converted prefab in the level had the correct PhysX Mesh Collider. Spawned Kraken Robot and drive around.