### PR TITLE
Update ROSConDemo docker default branches

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,10 +11,10 @@ ARG IMAGE_TYPE=full  # Default to 'full'
 
 # Arguments for the source repos 
 ARG O3DE_REPO=https://github.com/o3de/o3de.git
-ARG O3DE_BRANCH=ff4c065
+ARG O3DE_BRANCH=stabilization/2305
 
 ARG O3DE_EXTRAS_REPO=https://github.com/o3de/o3de-extras.git
-ARG O3DE_EXTRAS_BRANCH=4c13bbf
+ARG O3DE_EXTRAS_BRANCH=stabilization/2305
 
 ARG ROSCON_DEMO_REPO=https://github.com/o3de/ROSConDemo.git
 ARG ROSCON_DEMO_BRANCH=development

--- a/docker/README.md
+++ b/docker/README.md
@@ -70,11 +70,11 @@ The Dockerscripts use the following arguments to determine the repository to pul
 
 In addition to the repositories, the following arguments target the branch, commit, or tag to pull from their corresponding repository
 
-| Argument                | Repository                       | Default     |
-|-------------------------|----------------------------------|-------------|
-| O3DE_BRANCH             | O3DE                             | ff4c065     |
-| O3DE_EXTRAS_BRANCH      | O3DE Extras                      | 4c13bbf     |
-| ROSCON_DEMO_BRANCH      | ROSConDemo repository            | main        |
+| Argument                | Repository                       | Default                |
+|-------------------------|----------------------------------|------------------------|
+| O3DE_BRANCH             | O3DE                             | stabilization/2305     |
+| O3DE_EXTRAS_BRANCH      | O3DE Extras                      | stabilization/2305     |
+| ROSCON_DEMO_BRANCH      | ROSConDemo repository            | development            |
 
 ### Optimizing the build process ###
 The docker script provides a cmake-specific argument override to control the number of parallel jobs that can be used during the build of the docker image. `CMAKE_JOBS` sets the maximum number of concurrent jobs cmake will run during its build process and defaults to 8 jobs. This number can be adjusted to better suit the hardware which is running the docker image build.


### PR DESCRIPTION
Update the default git branches for the docker image to point to stabilization for o3de and o3de-extras. 
*Note: The current defaults are no longer valid