### PR TITLE
Update docker configuration (ROS and o3de)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,17 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 
-FROM ros:humble-ros-base-jammy
+FROM ros:iron-ros-base-jammy
 
 # Argument to control the type of docker image to build
 ARG IMAGE_TYPE=full  # Default to 'full'
 
 # Arguments for the source repos 
 ARG O3DE_REPO=https://github.com/o3de/o3de.git
-ARG O3DE_BRANCH=stabilization/2305
+ARG O3DE_BRANCH=2305.0
 
 ARG O3DE_EXTRAS_REPO=https://github.com/o3de/o3de-extras.git
-ARG O3DE_EXTRAS_BRANCH=stabilization/2305
+ARG O3DE_EXTRAS_BRANCH=2305.0
 
 ARG ROSCON_DEMO_REPO=https://github.com/o3de/ROSConDemo.git
 ARG ROSCON_DEMO_BRANCH=development
@@ -218,10 +218,10 @@ RUN echo "[Unit]" > /etc/systemd/system/setup_ros.service \
     && echo "After=network.target" >> /etc/systemd/system/setup_ros.service \
     && echo "" >> /etc/systemd/system/setup_ros.service \
     && echo "[Service]" >> /etc/systemd/system/setup_ros.service \
-    && if [ "${ROS_DISTRO}" = "humble" ]; then \
+    && if [ "${ROS_DISTRO}" = "iron" ]; then \
+         echo "ExecStart=/opt/ros/iron/setup.bash" >> /etc/systemd/system/setup_ros.service; \
+       elif [ "${ROS_DISTRO}" = "humble" ]; then \
          echo "ExecStart=/opt/ros/humble/setup.bash" >> /etc/systemd/system/setup_ros.service; \
-       elif [ "${ROS_DISTRO}" = "galactic" ]; then \
-         echo "ExecStart=/opt/ros/galactic/setup.bash" >> /etc/systemd/system/setup_ros.service; \
        fi \
     && echo "" >> /etc/systemd/system/setup_ros.service \
     && echo "[Install]" >> /etc/systemd/system/setup_ros.service \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 
-FROM ros:iron-ros-base-jammy
+ARG ROS_VERSION=humble
+ARG UBUNTU_VERSION=jammy
+￼
+FROM ros:${ROS_VERSION}-ros-base-${UBUNTU_VERSION}
 
 # Argument to control the type of docker image to build
 ARG IMAGE_TYPE=full  # Default to 'full'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -225,6 +225,8 @@ RUN echo "[Unit]" > /etc/systemd/system/setup_ros.service \
          echo "ExecStart=/opt/ros/iron/setup.bash" >> /etc/systemd/system/setup_ros.service; \
        elif [ "${ROS_DISTRO}" = "humble" ]; then \
          echo "ExecStart=/opt/ros/humble/setup.bash" >> /etc/systemd/system/setup_ros.service; \
+       elif [ "${ROS_DISTRO}" = "galactic" ]; then \
+         echo "ExecStart=/opt/ros/galactic/setup.bash" >> /etc/systemd/system/setup_ros.service; \
        fi \
     && echo "" >> /etc/systemd/system/setup_ros.service \
     && echo "[Install]" >> /etc/systemd/system/setup_ros.service \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,6 @@
 # Dockerfile for running the ROSConDemo
 
-The dockerfile defined in this path will prepare the appropriate ROS2 Humble distribution based environment and build the components necessary to run the ROSCon demo project simulator through the O3DE engine.  
-💡 ***Note:*** ROS 2 Iron is not yet supported.
+The dockerfile defined in this path will prepare the appropriate ROS2 Iron distribution based environment and build the components necessary to run the ROSCon demo project simulator through the O3DE engine.
 
 ## Prerequisites
 
@@ -14,7 +13,7 @@ The dockerfile defined in this path will prepare the appropriate ROS2 Humble dis
 
 ## Building the Docker Image
 
-The dockerfile supports defining which version of Ubuntu+ROS to base the docker container on, and by default will support Ubuntu 22.04 (jammy) with the ROS2 Humble distribution. This is currently the only version supported by the demo. The dockerfile will build an O3DE simulation environment that is configured to launch the O3DE editor, O3DE simulation launcher, and the simulation navigation stack used for the simulation.
+The dockerfile supports defining which version of Ubuntu+ROS to base the docker container on, and by default will support Ubuntu 22.04 (jammy) with the ROS2 Iron distribution. The dockerfile will build an O3DE simulation environment that is configured to launch the O3DE editor, O3DE simulation launcher, and the simulation navigation stack used for the simulation.
 
 To build the docker image for the ROSConDemo environment, run the following command:
 
@@ -73,8 +72,8 @@ In addition to the repositories, the following arguments target the branch, comm
 
 | Argument                | Repository                       | Default                |
 |-------------------------|----------------------------------|------------------------|
-| O3DE_BRANCH             | O3DE                             | stabilization/2305     |
-| O3DE_EXTRAS_BRANCH      | O3DE Extras                      | stabilization/2305     |
+| O3DE_BRANCH             | O3DE                             | 2305.0                 |
+| O3DE_EXTRAS_BRANCH      | O3DE Extras                      | 2305.0                 |
 | ROSCON_DEMO_BRANCH      | ROSConDemo repository            | development            |
 
 ### Optimizing the build process ###

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,9 +13,9 @@ The dockerfile defined in this path will prepare the appropriate ROS2 Iron distr
 
 ## Building the Docker Image
 
-The dockerfile supports defining which version of Ubuntu+ROS to base the docker container on, and by default will support Ubuntu 22.04 (jammy) with the ROS2 Iron distribution. The dockerfile will build an O3DE simulation environment that is configured to launch the O3DE editor, O3DE simulation launcher, and the simulation navigation stack used for the simulation.
+The dockerfile supports defining which version of Ubuntu+ROS to base the docker container on, and by default will support Ubuntu 22.04 (jammy) with the ROS2 Humble distribution. The dockerfile will build an O3DE simulation environment that is configured to launch the O3DE editor, O3DE simulation launcher, and the simulation navigation stack used for the simulation.
 
-To build the docker image for the ROSConDemo environment, run the following command:
+Run the following command to build the docker image for the ROSConDemo environment using default configuration:
 
 ```
 docker build -t roscon_demo -f Dockerfile .
@@ -25,7 +25,7 @@ This will create a `roscon_demo` docker image which will used when running the c
 
 
 **Note** 
-The above command example will build the full simulation environment needed to run the O3DE editor, O3DE simulation launcher, and the simulation navigation stack, based on the latest code from the o3de (O3DE Engine), o3de-extras (ROS2 Gem), and the ROSConDemo. The arguments specified will pull in the last known good version of the dependent projects from their repo. Additional arguments are available to customize and fine-tune this process and is described below.
+The above command example will build the full simulation environment needed to run the O3DE editor, O3DE simulation launcher, and the simulation navigation stack, based on the latest code from the o3de (O3DE Engine), o3de-extras (ROS2 Gem), and the ROSConDemo. The arguments specified will pull in the last known good version of the dependent projects from their repo. See the Advanced Options section below for more information.
 
 The build process may take over two hours depending on the hardware resource and network connectivity of the machine used to build the image.
 
@@ -57,12 +57,22 @@ To launch the O3DE simulation launcher for the ROSConDemo project, execute the f
 To spawn or launch the rviz visualizer, follow the [kraken_nav README file](https://github.com/o3de/ROSConDemo/blob/development/kraken_nav/README.md#running-simulation)
 
 ## Advanced Options
+
+### Target ROS2 Distribution
+The Docker script defaults to building an image based on Ubuntu 22.04 (jammy) and the ROS2 Humble distribution. This can be overridden with a combination of the `ROS_VERSION` and `UBUNTU_VERSION` arguments.
+
+| Arguments                                 | ROS2 Distro   |
+|-------------------------------------------|---------------|
+| ROS_VERSION=galactic UBUNTU_VERSION=focal | galactic      |
+| ROS_VERSION=humble   UBUNTU_VERSION=jammy | humble        |
+| ROS_VERSION=iron     UBUNTU_VERSION=jammy | iron          |
+
 ### Custom source repos and branches
 
 The Dockerscripts use the following arguments to determine the repository to pull the source from. 
 
-| Argument              | Repository                       | Default     |
-|-----------------------|----------------------------------|-------------|
+| Argument              | Repository                       | Default                                            |
+|-----------------------|----------------------------------|----------------------------------------------------|
 | O3DE_REPO             | O3DE                             | https://github.com/o3de/o3de.git                   |
 | O3DE_EXTRAS_REPO      | O3DE Extras                      | https://github.com/o3de/o3de-extras.git            |
 | ROSCON_DEMO_REPO      | ROSConDemo repository            | https://github.com/o3de/RobotVacuumSample          |


### PR DESCRIPTION
It was double-checked that the demo works correctly in docker container with _iron_ installed.

The changes are following:
* update default ROS distro in _Dockerfile_ to _iron_
* remove the comment about non-existing _iron_ docker in readme
* update default _o3de_ and _o3de-extras_ branches from _stabilization_ into official releases of the same versions