### PR TITLE
Fix crash for ROSCon2022 demo when launching from the `ROSConDemo.GameLauncher`

### DIFF
--- a/Project/Gem/Source/ROSConDemoSystemComponent.cpp
+++ b/Project/Gem/Source/ROSConDemoSystemComponent.cpp
@@ -70,6 +70,7 @@ namespace ROSConDemo
 
     void ROSConDemoSystemComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
+        incompatible.push_back(AZ_CRC("ROS2Service"));
     }
 
     void ROSConDemoSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)

--- a/Project/Gem/Source/ROSConDemoSystemComponent.cpp
+++ b/Project/Gem/Source/ROSConDemoSystemComponent.cpp
@@ -70,7 +70,8 @@ namespace ROSConDemo
 
     void ROSConDemoSystemComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
-        incompatible.push_back(AZ_CRC("ROS2Service"));
+        required.push_back(AZ_CRC_CE("ROS2Service"));
+
     }
 
     void ROSConDemoSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)


### PR DESCRIPTION
When launching the Agriculture demo (From ROSCon2022) using the `ROSCon.GameLauncher`, the launcher crashes with a segmentation fault. But starting game mode from the Editor does not crash. This is due to the fact that the editor will load the 'ROS2SystemComponent', but the ROSCon demo does not, but it does require the `ROS2Interface` 

```
    void ROSConDemoSystemComponent::Activate()
    {
        ROSConDemoRequestBus::Handler::BusConnect();
        auto ros2Node = ROS2::ROS2Interface::Get()->GetNode();
        m_pathPlanService = ros2Node->create_service<nav_msgs::srv::GetPlan>(
            m_planTopic.c_str(),
            [this](const GetPlanRequestPtr request, GetPlanResponsePtr response)
            {
                this->ProcessGetPlanServiceCall(request, response);
            });
    }
```
Adding `ROS2Service` to the required service for the ROSConDemoSystemComponent ensures that the ROS2SystemComponent is loaded and available since it provides the `ROS2Service`
