### PR TITLE
Fix scene settings.

### DIFF
--- a/Project/Registry/sceneassetimporter.setreg
+++ b/Project/Registry/sceneassetimporter.setreg
@@ -3,17 +3,6 @@
 	{
 		"SceneAPI":
 		{
-			"AssetImporter":
-			{
-				"SupportedFileTypeExtensions":
-				[
-					".dae",
-					".fbx",
-					".stl",
-					".gltf",
-					".glb"
-				]
-			},
 			"MaterialConverter": 
 			{
 				"Enable": true,


### PR DESCRIPTION
The ROS2 Gem has the correct defaults, so the project shouldn't override it.