### PR TITLE
Update Roscon 2022 Docker

### DIFF
--- a/Project/AssetBundling/SeedLists/ROSCon2022.seed
+++ b/Project/AssetBundling/SeedLists/ROSCon2022.seed
@@ -1,0 +1,36 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "AZStd::vector<SeedInfo, allocator>",
+    "ClassData": [
+        {
+            "assetId": {
+                "guid": "{F556BF02-7065-505E-B81D-66BA396692A0}",
+                "subId": 3771340206
+            },
+            "platformFlags": 2,
+            "pathHint": "levels/main/main.spawnable"
+        },
+        {
+            "assetId": {
+                "guid": "{65878C59-19C8-507F-B361-C0D4B90C15F3}"
+            },
+            "platformFlags": 2,
+            "pathHint": "thirdpersoncamera.inputbindings"
+        },
+        {
+            "assetId": {
+                "guid": "{0E98ABD6-E619-5C16-9B27-D9096E4B159A}"
+            },
+            "platformFlags": 2,
+            "pathHint": "thirdpersonmovement.inputbindings"
+        },
+        {
+            "assetId": {
+                "guid": "{1CBEE567-0954-59BA-8205-93BE85D07D0B}"
+            },
+            "platformFlags": 2,
+            "pathHint": "autoexec.cfg"
+        }
+    ]
+}

--- a/Project/Assets/Kraken/apple_kraken_v1/apple_kraken_v1.prefab
+++ b/Project/Assets/Kraken/apple_kraken_v1/apple_kraken_v1.prefab
@@ -4056,6 +4056,9 @@
                     "$type": "EditorColliderComponent",
                     "Id": 5289266319031448357,
                     "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 1
+                        },
                         "Trigger": true,
                         "MaterialSlots": {
                             "Slots": [

--- a/Project/Assets/Kraken/apple_kraken_v2/apple_kraken_v2.prefab
+++ b/Project/Assets/Kraken/apple_kraken_v2/apple_kraken_v2.prefab
@@ -4718,6 +4718,9 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10590573249310138745,
                     "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 1
+                        },
                         "Trigger": true,
                         "MaterialSlots": {
                             "Slots": [

--- a/Project/Gem/CMakeLists.txt
+++ b/Project/Gem/CMakeLists.txt
@@ -47,7 +47,6 @@ ly_add_target(
             Gem::EMotionFX.Static
             Gem::LmbrCentral.API
             Gem::LyShine
-            Gem::AtomLyIntegration_CommonFeatures.Editor.Static
             Gem::Atom_AtomBridge.Static
             Gem::ImGui.Static
             Gem::PhysX.Static

--- a/Project/Gem/Source/DemoStatistics/DemoStatisticsComponent.cpp
+++ b/Project/Gem/Source/DemoStatistics/DemoStatisticsComponent.cpp
@@ -10,7 +10,6 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <LyShine/Bus/UiCanvasBus.h>
 #include <LyShine/Bus/UiTextBus.h>
 #include <LyShine/Bus/World/UiCanvasRefBus.h>

--- a/Project/Gem/Source/FruitStorage/FruitStorageComponent.cpp
+++ b/Project/Gem/Source/FruitStorage/FruitStorageComponent.cpp
@@ -8,11 +8,11 @@
 
 #include "FruitStorageComponent.h"
 #include "FruitStorageBus.h"
+#include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Components/TransformComponent.h>
-#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 
 namespace AppleKraken
 {

--- a/Project/Gem/Source/Manipulator/KrakenManipulatorController.cpp
+++ b/Project/Gem/Source/Manipulator/KrakenManipulatorController.cpp
@@ -11,7 +11,6 @@
 #include <AzCore/Serialization/EditContext.h>
 
 #include <AzFramework/Components/TransformComponent.h>
-#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 
 namespace AppleKraken
 {

--- a/Project/Gem/enabled_gems.cmake
+++ b/Project/Gem/enabled_gems.cmake
@@ -3,7 +3,6 @@ set(ENABLED_GEMS
     ROSConDemo
     Atom
     AudioSystem
-    AWSCore
     CameraFramework
     DebugDraw
     EditorPythonBindings

--- a/Project/Levels/Main/Main.prefab
+++ b/Project/Levels/Main/Main.prefab
@@ -380,6 +380,26 @@
                         "Entity_[292446084420721]",
                         "Entity_[4575349763039]"
                     ]
+                },
+                "EditorHeightfieldColliderComponent": {
+                    "$type": "EditorHeightfieldColliderComponent",
+                    "Id": 12906038322501121030,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {},
+                                {
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{6D044767-4E3B-5116-A1A7-9C65BCF586A0}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "physx/terrain_dirt.physicsmaterial"
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 }
             }
         },
@@ -654,23 +674,8 @@
                 "Component_[13711420870643673468]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 13711420870643673468,
-                    "DisabledComponents": [
-                        {
-                            "$type": "AZ::Render::EditorMeshComponent",
-                            "Id": 5675108321710651991,
-                            "Controller": {
-                                "Configuration": {
-                                    "ModelAsset": {
-                                        "assetId": {
-                                            "guid": "{0CD745C0-6AA8-569A-A68A-73A3270986C4}",
-                                            "subId": 277889906
-                                        },
-                                        "assetHint": "objects/groudplane/groundplane_512x512m.azmodel"
-                                    }
-                                }
-                            }
-                        },
-                        {
+                    "DisabledComponents": {
+                        "Component_[5182430712893438093]": {
                             "$type": "EditorMaterialComponent",
                             "Id": 5182430712893438093,
                             "Controller": {
@@ -685,8 +690,23 @@
                                     ]
                                 }
                             }
+                        },
+                        "Component_[5675108321710651991]": {
+                            "$type": "AZ::Render::EditorMeshComponent",
+                            "Id": 5675108321710651991,
+                            "Controller": {
+                                "Configuration": {
+                                    "ModelAsset": {
+                                        "assetId": {
+                                            "guid": "{0CD745C0-6AA8-569A-A68A-73A3270986C4}",
+                                            "subId": 277889906
+                                        },
+                                        "assetHint": "objects/groudplane/groundplane_512x512m.azmodel"
+                                    }
+                                }
+                            }
                         }
-                    ]
+                    }
                 },
                 "Component_[138002849734991713]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -780,8 +800,7 @@
                     "Id": 16880285896855930892,
                     "Controller": {
                         "Configuration": {
-                            "Field of View": 55.0,
-                            "EditorEntityId": 3659314624400262759
+                            "Field of View": 55.0
                         }
                     }
                 },
@@ -954,8 +973,8 @@
                 "Component_[14994774102579326069]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 14994774102579326069,
-                    "DisabledComponents": [
-                        {
+                    "DisabledComponents": {
+                        "Component_[13126383555450060198]": {
                             "$type": "AZ::Render::EditorPhysicalSkyComponent",
                             "Id": 13126383555450060198,
                             "Controller": {
@@ -973,7 +992,7 @@
                                 }
                             }
                         }
-                    ]
+                    }
                 },
                 "Component_[15417479889044493340]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -1402,8 +1421,8 @@
                 "Component_[13792978816524169234]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13792978816524169234,
-                    "PendingComponents": [
-                        {
+                    "PendingComponents": {
+                        "Component_[15045768458115272767]": {
                             "$type": "EditorMaterialComponent",
                             "Id": 15045768458115272767,
                             "Controller": {
@@ -1426,7 +1445,7 @@
                                 }
                             }
                         }
-                    ]
+                    }
                 },
                 "Component_[16045467262737659182]": {
                     "$type": "EditorEntityIconComponent",
@@ -1443,8 +1462,8 @@
                 "Component_[4111006409936537498]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4111006409936537498,
-                    "DisabledComponents": [
-                        {
+                    "DisabledComponents": {
+                        "Component_[13042287448449165802]": {
                             "$type": "AZ::Render::EditorMeshComponent",
                             "Id": 13042287448449165802,
                             "Controller": {
@@ -1460,7 +1479,7 @@
                                 }
                             }
                         }
-                    ]
+                    }
                 },
                 "Component_[5287415047203296639]": {
                     "$type": "EditorEntitySortComponent",
@@ -5527,7 +5546,6 @@
                             "Name": "line2"
                         }
                     }
-
                 },
                 "Component_[2840753425454738983]": {
                     "$type": "EditorLockComponent",
@@ -9833,6 +9851,16 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[6372788350921479434]/Transform Data/Translate/1",
                     "value": 44.92060852050781
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1327675221987453]/Components/Component_[14322969105034715544]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "assets/props/barrel.fbx.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1327675221987453]/Components/Component_[14322969105034715544]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "assets/props/barrel.fbx.pxmesh"
                 }
             ]
         },
@@ -9853,6 +9881,16 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[6372788350921479434]/Transform Data/Translate/1",
                     "value": 45.00574493408203
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1327675221987453]/Components/Component_[14322969105034715544]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "assets/props/barrel.fbx.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1327675221987453]/Components/Component_[14322969105034715544]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "assets/props/barrel.fbx.pxmesh"
                 }
             ]
         },
@@ -9873,6 +9911,16 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[6372788350921479434]/Transform Data/Translate/1",
                     "value": 48.65117263793945
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1327675221987453]/Components/Component_[14322969105034715544]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "assets/props/barrel.fbx.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1327675221987453]/Components/Component_[14322969105034715544]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "assets/props/barrel.fbx.pxmesh"
                 }
             ]
         },
@@ -9903,6 +9951,16 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[16733126560870675783]/Transform Data/Rotate/2",
                     "value": 21.698911666870117
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1328345236885629]/Components/Component_[3012283993462436523]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "assets/props/crate_01.fbx.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1328345236885629]/Components/Component_[3012283993462436523]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "assets/props/crate_01.fbx.pxmesh"
                 }
             ]
         },
@@ -9933,6 +9991,16 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[16733126560870675783]/Transform Data/Rotate/2",
                     "value": 32.39841842651367
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1328345236885629]/Components/Component_[3012283993462436523]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "assets/props/crate_01.fbx.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1328345236885629]/Components/Component_[3012283993462436523]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "assets/props/crate_01.fbx.pxmesh"
                 }
             ]
         },
@@ -9973,6 +10041,16 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[5123579376316041771]/Transform Data/Rotate/2",
                     "value": 69.76118469238281
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1327950099894397]/Components/Component_[9744507723268008838]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "assets/props/wagonwheel_01.fbx.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[1327950099894397]/Components/Component_[9744507723268008838]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "assets/props/wagonwheel_01.fbx.pxmesh"
                 }
             ]
         },
@@ -9998,6 +10076,16 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15439992882160637816]/Transform Data/Rotate/2",
                     "value": 72.40711212158203
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[30058651448823]/Components/Component_[16842351070526488773]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "assets/windmill_01/windmill_01.fbx.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[30058651448823]/Components/Component_[16842351070526488773]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "assets/windmill_01/windmill_01.fbx.pxmesh"
                 }
             ]
         },
@@ -10028,6 +10116,16 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1344051213416318901]/Transform Data/Rotate/2",
                     "value": 14.720419883728027
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[477018013220429]/Components/Component_[13912151555249104113]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "assets/watertower_01/water_tower.fbx.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[477018013220429]/Components/Component_[13912151555249104113]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "assets/watertower_01/water_tower.fbx.pxmesh"
                 }
             ]
         },
@@ -11328,6 +11426,16 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[6958903478055170698]/Transform Data/Rotate/2",
                     "value": -66.4480209350586
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[945674658144]/Components/Component_[15791848428761537412]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "assets/barn/barn.fbx.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[945674658144]/Components/Component_[15791848428761537412]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "assets/barn/barn.fbx.pxmesh"
                 }
             ]
         },

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,16 +13,19 @@ ENV WORKSPACE=/data/workspace
 
 WORKDIR $WORKSPACE
 
+# O3DE Variables
 ARG O3DE_REPO=https://github.com/o3de/o3de.git
 ARG O3DE_BRANCH=main
 ARG O3DE_COMMIT=HEAD
 ENV O3DE_ROOT=$WORKSPACE/o3de
 
+# O3DE Extras Variables
 ARG O3DE_EXTRAS_REPO=https://github.com/o3de/o3de-extras.git
 ARG O3DE_EXTRAS_BRANCH=main
 ARG O3DE_EXTRAS_COMMIT=HEAD
 ENV O3DE_EXTRAS_ROOT=$WORKSPACE/o3de-extras
 
+# ROSConDemo Variables
 ARG ROSCON_DEMO_REPO=https://github.com/o3de/ROSConDemo.git
 ARG ROSCON_DEMO_BRANCH=development
 ARG ROSCON_DEMO_COMMIT=HEAD
@@ -30,7 +33,7 @@ ENV ROSCON_DEMO_ROOT=$WORKSPACE/ROSConDemo
 ENV ROSCON_DEMO_PROJECT=$ROSCON_DEMO_ROOT/Project
 ENV ROSCON_DEMO_NAV_ROOT=$ROSCON_DEMO_ROOT/kraken_nav
 
-# Copy the current project contents to the docker container
+# Copy the release-patch in case its needed
 COPY docker/o3de_2.1.0.patch $WORKSPACE/
 
 ENV LANG=en_US.UTF-8
@@ -87,12 +90,9 @@ RUN apt-get update \
             && rm -rf /var/lib/apt/lists/* \
             && pip install python-statemachine
 
-ENV O3DE_PROJECT_PATH=$WORKSPACE/Project
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
-#
-# Setup o3de and o3de-extras and prepare the environment and build the project.
-#
+# Clone, register, and build the projects
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
     \
     # Clone o3de \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -140,6 +140,7 @@ RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
                             -DLY_STRIP_DEBUG_SYMBOLS=ON \
                             -DAZ_USE_PHYSX5=ON \
     && cmake --build $ROSCON_DEMO_PROJECT/build/linux --config profile \
+             --target ROSConDemo.GameLauncher Editor ROSConDemo.Assets \
     \
     ############################################################### \
     # Build the Editor, Tools, and clients

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ ENV ROSCON_DEMO_PROJECT=$ROSCON_DEMO_ROOT/Project
 ENV ROSCON_DEMO_NAV_ROOT=$ROSCON_DEMO_ROOT/kraken_nav
 
 # Copy the release-patch in case its needed
-COPY docker/o3de_2.1.0.patch $WORKSPACE/
+COPY o3de_2.1.0.patch $WORKSPACE/
 
 ENV LANG=en_US.UTF-8
 

--- a/docker/Dockerfile.NavStack
+++ b/docker/Dockerfile.NavStack
@@ -11,13 +11,14 @@ FROM ros:${ROS_VERSION}-ros-base-${UBUNTU_VERSION}
 
 ENV WORKSPACE=/data/workspace
 
+WORKDIR $WORKSPACE
+
+# ROSConDemo Variables
 ARG ROSCON_DEMO_REPO=https://github.com/o3de/ROSConDemo.git
 ARG ROSCON_DEMO_BRANCH=development
 ARG ROSCON_DEMO_COMMIT=HEAD
 ENV ROSCON_DEMO_ROOT=$WORKSPACE/ROSConDemo
 ENV ROSCON_DEMO_NAV_ROOT=$WORKSPACE/kraken_nav
-
-WORKDIR $WORKSPACE
 
 ENV LANG=en_US.UTF-8
 
@@ -61,8 +62,7 @@ RUN apt-get update \
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
-#
-#
+# Clone and build the navstack project
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
     ############################################################### \
     # Clone the ROSConDemo \
@@ -73,7 +73,6 @@ RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
     && git -C $ROSCON_DEMO_ROOT reset --hard $ROSCON_DEMO_COMMIT \
     && mv $ROSCON_DEMO_ROOT/kraken_nav $ROSCON_DEMO_NAV_ROOT \
     && rm -rf $ROSCON_DEMO_ROOT
-
 
 # Build the navigation stack
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \

--- a/docker/Dockerfile.NavStack
+++ b/docker/Dockerfile.NavStack
@@ -1,0 +1,101 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+ARG ROS_VERSION=humble
+ARG UBUNTU_VERSION=jammy
+
+FROM ros:${ROS_VERSION}-ros-base-${UBUNTU_VERSION}
+
+ENV WORKSPACE=/data/workspace
+
+ARG ROSCON_DEMO_REPO=https://github.com/o3de/ROSConDemo.git
+ARG ROSCON_DEMO_BRANCH=development
+ARG ROSCON_DEMO_COMMIT=HEAD
+ENV ROSCON_DEMO_ROOT=$WORKSPACE/ROSConDemo
+ENV ROSCON_DEMO_NAV_ROOT=$WORKSPACE/kraken_nav
+
+WORKDIR $WORKSPACE
+
+ENV LANG=en_US.UTF-8
+
+# Setup time zone and locale data (necessary for SSL and HTTPS packages)
+RUN apt-get update \
+    && DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata locales keyboard-configuration curl \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && dpkg-reconfigure --frontend=noninteractive locales \
+    && update-locale LANG=en_US.UTF-8 \
+    && sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list' \
+    && curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add - \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the required ubuntu packages
+RUN apt-get update \
+    && apt-get install -y \
+            python3 \
+            python3-pip \
+            git \
+            git-lfs \
+            software-properties-common \
+            ros-${ROS_DISTRO}-ackermann-msgs \
+            ros-${ROS_DISTRO}-control-toolbox \
+            ros-${ROS_DISTRO}-gazebo-msgs \
+            ros-${ROS_DISTRO}-joy \
+            ros-${ROS_DISTRO}-navigation2 \
+            ros-${ROS_DISTRO}-rviz2 \
+            ros-${ROS_DISTRO}-tf2-ros \
+            ros-${ROS_DISTRO}-urdfdom \
+            ros-${ROS_DISTRO}-vision-msgs \
+            ros-${ROS_DISTRO}-cyclonedds \
+            ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+            ros-${ROS_DISTRO}-slam-toolbox \
+            ros-${ROS_DISTRO}-nav2-bringup \
+            ros-${ROS_DISTRO}-pointcloud-to-laserscan \
+            ros-${ROS_DISTRO}-teleop-twist-keyboard \
+            ros-${ROS_DISTRO}-topic-tools \
+            python3-colcon-common-extensions \
+            && rm -rf /var/lib/apt/lists/* \
+            && pip install python-statemachine
+
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+
+#
+#
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    ############################################################### \
+    # Clone the ROSConDemo \
+    ############################################################### \
+    && git clone --single-branch -b $ROSCON_DEMO_BRANCH $ROSCON_DEMO_REPO $ROSCON_DEMO_ROOT \
+    && git -C $ROSCON_DEMO_ROOT lfs install \
+    && git -C $ROSCON_DEMO_ROOT lfs pull \
+    && git -C $ROSCON_DEMO_ROOT reset --hard $ROSCON_DEMO_COMMIT \
+    && mv $ROSCON_DEMO_ROOT/kraken_nav $ROSCON_DEMO_NAV_ROOT \
+    && rm -rf $ROSCON_DEMO_ROOT
+
+
+# Build the navigation stack
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && cd $ROSCON_DEMO_NAV_ROOT \
+    && colcon build --symlink-install
+
+# Add the appropriate ros2 environment setup script to the system startup
+RUN echo "[Unit]" > /etc/systemd/system/setup_ros.service \
+    && echo "After=network.target" >> /etc/systemd/system/setup_ros.service \
+    && echo "" >> /etc/systemd/system/setup_ros.service \
+    && echo "[Service]" >> /etc/systemd/system/setup_ros.service \
+    && if [ "${ROS_DISTRO}" = "iron" ]; then \
+         echo "ExecStart=/opt/ros/iron/setup.bash" >> /etc/systemd/system/setup_ros.service; \
+       elif [ "${ROS_DISTRO}" = "humble" ]; then \
+         echo "ExecStart=/opt/ros/humble/setup.bash" >> /etc/systemd/system/setup_ros.service; \
+       elif [ "${ROS_DISTRO}" = "galactic" ]; then \
+         echo "ExecStart=/opt/ros/galactic/setup.bash" >> /etc/systemd/system/setup_ros.service; \
+       fi \
+    && echo "" >> /etc/systemd/system/setup_ros.service \
+    && echo "[Install]" >> /etc/systemd/system/setup_ros.service \
+    && echo "WantedBy=default.target" >> /etc/systemd/system/setup_ros.service \
+    && echo "" >> /etc/systemd/system/setup_ros.service
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES all

--- a/docker/Dockerfile.Simulation
+++ b/docker/Dockerfile.Simulation
@@ -11,8 +11,6 @@ FROM ros:${ROS_VERSION}-ros-base-${UBUNTU_VERSION}
 
 ENV WORKSPACE=/data/workspace
 
-WORKDIR $WORKSPACE
-
 ARG O3DE_REPO=https://github.com/o3de/o3de.git
 ARG O3DE_BRANCH=main
 ARG O3DE_COMMIT=HEAD
@@ -28,9 +26,16 @@ ARG ROSCON_DEMO_BRANCH=development
 ARG ROSCON_DEMO_COMMIT=HEAD
 ENV ROSCON_DEMO_ROOT=$WORKSPACE/ROSConDemo
 ENV ROSCON_DEMO_PROJECT=$ROSCON_DEMO_ROOT/Project
-ENV ROSCON_DEMO_NAV_ROOT=$ROSCON_DEMO_ROOT/kraken_nav
+ENV ROSCON_DEMO_NAV_ROOT=$WORKSPACE/kraken_nav
+ENV ROSCON_DEMO_SEEDLIST=$ROSCON_DEMO_ROOT/Project/AssetBundling/SeedLists/ROSCon2022.seed
+
+
+WORKDIR $WORKSPACE
 
 # Copy the current project contents to the docker container
+#COPY Project $WORKSPACE/Project
+#COPY kraken_nav $WORKSPACE/kraken_nav
+
 COPY docker/o3de_2.1.0.patch $WORKSPACE/
 
 ENV LANG=en_US.UTF-8
@@ -87,7 +92,6 @@ RUN apt-get update \
             && rm -rf /var/lib/apt/lists/* \
             && pip install python-statemachine
 
-ENV O3DE_PROJECT_PATH=$WORKSPACE/Project
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
 #
@@ -122,42 +126,34 @@ RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
     && git -C $ROSCON_DEMO_ROOT lfs install \
     && git -C $ROSCON_DEMO_ROOT lfs pull \
     && git -C $ROSCON_DEMO_ROOT reset --hard $ROSCON_DEMO_COMMIT \
+    && cp -r $ROSCON_DEMO_ROOT/kraken_nav $ROSCON_DEMO_NAV_ROOT \
     \
     ############################################################### \
     # Get the O3DE python and register the gem paths and projects \
     ############################################################### \
-    && $O3DE_ROOT/python/get_python.sh \
-    && $O3DE_ROOT/scripts/o3de.sh register -ep $O3DE_ROOT \
-    && $O3DE_ROOT/scripts/o3de.sh register -gp $O3DE_EXTRAS_ROOT/Gems/ROS2 \
-    && $O3DE_ROOT/scripts/o3de.sh register -pp $ROSCON_DEMO_PROJECT \
+    && $WORKSPACE/o3de/python/get_python.sh \
+    && $WORKSPACE/o3de/scripts/o3de.sh register -ep $O3DE_ROOT \
+    && $WORKSPACE/o3de/scripts/o3de.sh register -gp $O3DE_EXTRAS_ROOT/Gems/ROS2 \
+    && $WORKSPACE/o3de/scripts/o3de.sh register -pp $ROSCON_DEMO_PROJECT \
     \
-    ############################################################### \
-    # Build the Editor, Tools, and clients
-    ############################################################### \
-    && cmake -B $ROSCON_DEMO_PROJECT/build/linux -G "Ninja Multi-Config" \
-                            -S $ROSCON_DEMO_PROJECT \
-                            -DLY_DISABLE_TEST_MODULES=ON \
-                            -DLY_STRIP_DEBUG_SYMBOLS=ON \
-                            -DAZ_USE_PHYSX5=ON \
-    && cmake --build $ROSCON_DEMO_PROJECT/build/linux --config profile \
+    # Run the project exporter to generate the ROSConDemo release package \
     \
-    ############################################################### \
-    # Build the Editor, Tools, and clients
-    ############################################################### \
-    && rm -rf ~/.o3de/3rdParty/ \
-    && rm -rf $O3DE_ROOT/.git \
-    && rm -rf $O3DE_ROOT/AutomatedTesting \
-    && rm -rf $O3DE_ROOT/python/downloaded_packages \
-    && rm -rf $ROSCON_DEMO_PROJECT/build/linux/Azcg/ \
-    && rm -rf $ROSCON_DEMO_PROJECT/build/linux/CMake \
-    && rm -rf $ROSCON_DEMO_PROJECT/build/linux/CMakeFiles/ \
-    && rm -rf $ROSCON_DEMO_PROJECT/build/linux/External/ \
-    && rm -rf $ROSCON_DEMO_PROJECT/build/linux/Testing/ \
-    && rm -rf $ROSCON_DEMO_PROJECT/build/linux/_deps/ \
-    && rm -rf $ROSCON_DEMO_PROJECT/build/linux/cmake \
-    && rm -rf $ROSCON_DEMO_PROJECT/build/linux/lib/ \
-    && rm -rf $ROSCON_DEMO_PROJECT/build/linux/o3de/ \
-    && rm -rf $ROSCON_DEMO_PROJECT/build/linux/packages/
+    && $O3DE_ROOT/scripts/o3de.sh export-project -es ExportScripts/export_source_built_project.py \
+                                    --project-path $ROSCON_DEMO_PROJECT \
+                                    --log-level INFO \
+                                    -assets \
+                                    --build-tools \
+                                    --config release \
+                                    --archive-output none \
+                                    --seedlist $ROSCON_DEMO_SEEDLIST \
+                                    -noserver \
+                                    -nounified \
+                                    -out $WORKSPACE \
+    && rm -rf $ROSCON_DEMO_ROOT \
+    && rm -rf $O3DE_EXTRAS_ROOT \
+    && rm -rf $WORKSPACE/o3de-extras \
+    && rm -rf /root/.o3de \
+    && rm -rf /root/O3DE
 
 # Build the navigation stack
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \

--- a/docker/Dockerfile.Simulation
+++ b/docker/Dockerfile.Simulation
@@ -11,16 +11,21 @@ FROM ros:${ROS_VERSION}-ros-base-${UBUNTU_VERSION}
 
 ENV WORKSPACE=/data/workspace
 
+WORKDIR $WORKSPACE
+
+# O3DE Variables
 ARG O3DE_REPO=https://github.com/o3de/o3de.git
 ARG O3DE_BRANCH=main
 ARG O3DE_COMMIT=HEAD
 ENV O3DE_ROOT=$WORKSPACE/o3de
 
+# O3DE Extras Variables
 ARG O3DE_EXTRAS_REPO=https://github.com/o3de/o3de-extras.git
 ARG O3DE_EXTRAS_BRANCH=main
 ARG O3DE_EXTRAS_COMMIT=HEAD
 ENV O3DE_EXTRAS_ROOT=$WORKSPACE/o3de-extras
 
+# ROSConDemo Variables
 ARG ROSCON_DEMO_REPO=https://github.com/o3de/ROSConDemo.git
 ARG ROSCON_DEMO_BRANCH=development
 ARG ROSCON_DEMO_COMMIT=HEAD
@@ -29,13 +34,7 @@ ENV ROSCON_DEMO_PROJECT=$ROSCON_DEMO_ROOT/Project
 ENV ROSCON_DEMO_NAV_ROOT=$WORKSPACE/kraken_nav
 ENV ROSCON_DEMO_SEEDLIST=$ROSCON_DEMO_ROOT/Project/AssetBundling/SeedLists/ROSCon2022.seed
 
-
-WORKDIR $WORKSPACE
-
-# Copy the current project contents to the docker container
-#COPY Project $WORKSPACE/Project
-#COPY kraken_nav $WORKSPACE/kraken_nav
-
+# Copy the release-patch in case its needed
 COPY docker/o3de_2.1.0.patch $WORKSPACE/
 
 ENV LANG=en_US.UTF-8
@@ -94,9 +93,7 @@ RUN apt-get update \
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
-#
-# Setup o3de and o3de-extras and prepare the environment and build the project.
-#
+# Clone, register, and build the projects
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
     \
     # Clone o3de \

--- a/docker/Dockerfile.Simulation
+++ b/docker/Dockerfile.Simulation
@@ -35,7 +35,7 @@ ENV ROSCON_DEMO_NAV_ROOT=$WORKSPACE/kraken_nav
 ENV ROSCON_DEMO_SEEDLIST=$ROSCON_DEMO_ROOT/Project/AssetBundling/SeedLists/ROSCon2022.seed
 
 # Copy the release-patch in case its needed
-COPY docker/o3de_2.1.0.patch $WORKSPACE/
+COPY o3de_2.1.0.patch $WORKSPACE/
 
 ENV LANG=en_US.UTF-8
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -79,7 +79,7 @@ Also included are custom Dockerscripts that will only build the components neces
 * Dockerfile.NavStack
   The Docker image created from this script will only havethe compiled `kraken_nav` code for the navigation stack.
 
-These images will be much smaller that the full `roscon_demo` docker image. 
+These images will be much smaller than the full `roscon_demo` docker image. 
 
 To build the `roscon_sim` Docker image, run the following build command from this `docker` subfolder of this project:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -51,7 +51,7 @@ rocker --x11 --nvidia --network="bridge" roscon_demo
 **Note**
 The above command will log you into the docker terminal that has the `kraken_nav` code built, but will not activate the environment until you run the following command after logging in:
 ```
-source /data/workspace/kraken_nav/install/setup.bash
+source /data/workspace/ROSConDemo/kraken_nav/install/setup.bash
 ```
 
 To launch the O3DE editor for the ROSConDemo project, execute the following command within the docker terminal

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,7 @@ There are three Dockerfile scripts that are designed to provide environments to 
 This Dockerfile will build a docker container that will have the simulation launcher (`ROSConDemo.GameLauncher`), the `kraken_nav` code for the navigation stack, and the `Editor` which can be used to view the demo level and assets.
 
 ### Dockerfile.NavStack
-This Dockerfile will build a docker container will only have the `kraken_nav` code for the navigation stack.
+This Dockerfile will build a docker container that will only have the `kraken_nav` code for the navigation stack.
 
 ### Dockerfile.Simulation
 This Dockerfile will build a docker container that will have the simulation launcher (`ROSConDemo.GameLauncher`) and the `kraken_nav` code for the navigation stack.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,18 @@
-# Dockerfile for running the ROSConDemo
+# Dockerfiles for running the ROSConDemo
 
-The dockerfile defined in this path will prepare the appropriate ROS2 Iron distribution based environment and build the components necessary to run the ROSCon demo project simulator through the O3DE engine.
+The Dockerfile defined in this path will prepare the appropriate ROS2 Iron distribution based environment and build the components necessary to run the ROSCon demo project simulator through the O3DE engine.
+
+There are three Dockerfile scripts that are designed to provide environments to both run the ROSCon demo project simulation, and to run the ROSCon editor to open and view the demo level and assets for closer inspection. (Note that the editor environment is meant for demonstrative purposes only and not intended for actual editing and authoring)
+
+### Dockerfile
+This Dockerfile will build a docker container that will have the simulation launcher (`ROSConDemo.GameLauncher`), the `kraken_nav` code for the navigation stack, and the `Editor` which can be used to view the demo level and assets.
+
+### Dockerfile.NavStack
+This Dockerfile will build a docker container will only have the `kraken_nav` code for the navigation stack.
+
+### Dockerfile.Simulation
+This Dockerfile will build a docker container that will have the simulation launcher (`ROSConDemo.GameLauncher`) and the `kraken_nav` code for the navigation stack.
+
 
 ## Prerequisites
 
@@ -11,23 +23,20 @@ The dockerfile defined in this path will prepare the appropriate ROS2 Iron distr
   * **Note** It is recommended to have Docker installed correctly and in a secure manner so that the docker commands in this guide do not require elevated privileges (sudo) in order to run them. See [Docker Engine post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) for more details.
 * [NVidia container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 
-## Building the Docker Image
 
-The dockerfile supports defining which version of Ubuntu+ROS to base the docker container on, and by default will support Ubuntu 22.04 (jammy) with the ROS2 Humble distribution. The dockerfile will build an O3DE simulation environment that is configured to launch the O3DE editor, O3DE simulation launcher, and the simulation navigation stack used for the simulation.
+## Building the Full Docker Image
 
-Run the following command to build the docker image for the ROSConDemo environment using default configuration:
+The dockerfile supports defining which version of Ubuntu+ROS to base the docker container on, and by default will support Ubuntu 22.04 (jammy) with the ROS2 Humble distribution. The main `Dockerfile` will build a Docker image that will contain the Editor, RosConDemo launcher, and the kraken_nav navigation stack code. To build the full docker image into a container called `roscon_demo`, run the following build command from this `docker` subfolder of this project:
 
 ```
 docker build -t roscon_demo -f Dockerfile .
 ```
 
-This will create a `roscon_demo` docker image which will used when running the container.
-
-
 **Note** 
 The above command example will build the full simulation environment needed to run the O3DE editor, O3DE simulation launcher, and the simulation navigation stack, based on the latest code from the o3de (O3DE Engine), o3de-extras (ROS2 Gem), and the ROSConDemo. The arguments specified will pull in the last known good version of the dependent projects from their repo. See the Advanced Options section below for more information.
 
 The build process may take over two hours depending on the hardware resource and network connectivity of the machine used to build the image.
+
 
 ## Running the Docker Image
 
@@ -36,9 +45,14 @@ GPU acceleration is required for running O3DE correctly. For running docker with
 Another option is to install and use [rocker](https://github.com/osrf/rocker).
 
 ```
-rocker --x11 --nvidia roscon_demo
+rocker --x11 --nvidia --network="bridge" roscon_demo
 ```
 
+**Note**
+The above command will log you into the docker terminal that has the `kraken_nav` code built, but will not activate the environment until you run the following command after logging in:
+```
+source /data/workspace/kraken_nav/install/setup.bash
+```
 
 To launch the O3DE editor for the ROSConDemo project, execute the following command within the docker terminal
 
@@ -55,6 +69,61 @@ To launch the O3DE simulation launcher for the ROSConDemo project, execute the f
 ```
 
 To spawn or launch the rviz visualizer, follow the [kraken_nav README file](https://github.com/o3de/ROSConDemo/blob/development/kraken_nav/README.md#running-simulation)
+
+
+## Building the reduced Docker Images for the Simulation/Navigation
+Also included are custom Dockerscripts that will only build the components necessary to launch and run the RosConDemo simulation only:
+
+* Dockerfile.Simulation
+  The Docker image created from this script will have a release-build packaged version of the simulation as well as the compiled `kraken_nav` code for the navigation stack.
+* Dockerfile.NavStack
+  The Docker image created from this script will only havethe compiled `kraken_nav` code for the navigation stack.
+
+These images will be much smaller that the full `roscon_demo` docker image. 
+
+To build the `roscon_sim` Docker image, run the following build command from this `docker` subfolder of this project:
+
+```
+docker build -t roscon_sim -f Dockerfile.Simulation .
+```
+
+To build the `roscon_nav` Docker image, run the following build command from this `docker` subfolder of this project:
+
+```
+docker build -t roscon_nav -f Dockerfile.NavStack .
+```
+
+## Running the Simulation Docker Image
+
+Similar to the steps to launch the `roscon_demo` image above, you can launch the simulation Docker image with the following command:
+
+```
+rocker --x11 --nvidia --network="bridge" roscon_sim
+```
+
+Once logged into the simulation docker terminal, you can launch the simulation with the following commands:
+
+```
+cd /data/workspace/ROSConDemoGamePackage
+./ROSConDemo.GameLauncher
+```
+
+## Running the Navigation Stack Docker Image
+
+Once the simulation is running, you can launch either the Navigation Stack Docker image, or launch another instance of the Simulation Docker image to control the simulation through ROS.
+
+```
+rocker --x11 --nvidia --network="bridge" roscon_nav
+```
+
+**Note**
+The above command will log you into the docker terminal that has the `kraken_nav` code built, but will not activate the environment until you run the following command after logging in:
+```
+source /data/workspace/kraken_nav/install/setup.bash
+```
+
+From this docker terminal, you will be able to run the demo scenario described in the [main README file](https://github.com/o3de/ROSConDemo/blob/development/README.md#running-the-demo-scenario)
+
 
 ## Advanced Options
 
@@ -82,32 +151,6 @@ In addition to the repositories, the following arguments target the branch, comm
 
 | Argument                | Repository                       | Default                |
 |-------------------------|----------------------------------|------------------------|
-| O3DE_BRANCH             | O3DE                             | 2305.0                 |
-| O3DE_EXTRAS_BRANCH      | O3DE Extras                      | 2305.0                 |
+| O3DE_BRANCH             | O3DE                             | main                   |
+| O3DE_EXTRAS_BRANCH      | O3DE Extras                      | main                   |
 | ROSCON_DEMO_BRANCH      | ROSConDemo repository            | development            |
-
-### Optimizing the build process ###
-The docker script provides a cmake-specific argument override to control the number of parallel jobs that can be used during the build of the docker image. `CMAKE_JOBS` sets the maximum number of concurrent jobs cmake will run during its build process and defaults to 8 jobs. This number can be adjusted to better suit the hardware which is running the docker image build.
-
-
-## Creating the Simulation only Docker Images.
-
-A slimmer docker image can be built that only contains the ROSConDemo simulation launcher and the kraken_nav navigation stack. The O3DE editor will not be part of the image, and therefore the build will take less time and less space. The argument `IMAGE_TYPE` can be set to `simulation` to create this docker image.
-
-
-The Dockerfile provides arguments to build docker images that only contain the necessary files to run the O3DE simulation launcher and the navigation stack, without the need to launch the O3DE Editor. To build the the docker image for just the simulation portion of the ROSConDemo, run the following command:
-
-```
-docker build --build-arg IMAGE_TYPE=simulation --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 -t roscon_demo_simulation -f Dockerfile .
-```
-
-## Creating a navigation stack only Docker Images.
-
-A minimal docker image that only contains the built `kraken_nav` navigation stack can also be specified. This is useful to have an image separate from the simulation environment to monitor and control the simulation through the ROS2 framework. The argument `IMAGE_TYPE` will need to be set to `navstack` to build this image. The image will be even smaller since it will not contain any O3DE simulation binaries or assets. It will have the necessary ROS2 packages including the rviz visualizer to view and control the simulation. To build the navigation stack only docker image, run the following command:
-
-```
-docker build --build-arg IMAGE_TYPE=navstack --build-arg O3DE_BRANCH=199205f --build-arg O3DE_EXTRAS_BRANCH=cbd3cd5 --build-arg ROSCON_DEMO_BRANCH=development -t roscon_demo_navstack -f Dockerfile .
-```
-
-
-

--- a/docker/README.md
+++ b/docker/README.md
@@ -77,7 +77,7 @@ Also included are custom Dockerscripts that will only build the components neces
 * Dockerfile.Simulation
   The Docker image created from this script will have a release-build packaged version of the simulation as well as the compiled `kraken_nav` code for the navigation stack.
 * Dockerfile.NavStack
-  The Docker image created from this script will only havethe compiled `kraken_nav` code for the navigation stack.
+  The Docker image created from this script will only have the compiled `kraken_nav` code for the navigation stack.
 
 These images will be much smaller than the full `roscon_demo` docker image. 
 

--- a/docker/o3de_2.1.0.patch
+++ b/docker/o3de_2.1.0.patch
@@ -1,0 +1,13 @@
+diff --git a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+index 99d0301016..3182cd319d 100644
+--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
++++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+@@ -297,7 +297,7 @@ namespace AZ
+             }
+ 
+             RHI::Ptr<RHI::XRDeviceDescriptor> xrDescriptor = m_rhiSystem.GetDevice()->BuildXRDescriptor();
+-            auto result = xrRender->CreateDevice(xrDescriptor.get());
++            [[maybe_unused]] auto result = xrRender->CreateDevice(xrDescriptor.get());
+             AZ_Error("RPISystem", result == RHI::ResultCode::Success, "Failed to initialize XR device");
+             AZ::RHI::XRSessionDescriptor sessionDescriptor;
+             result = xrRender->CreateSession(&sessionDescriptor);


### PR DESCRIPTION
Fixes and updates to the ROSConDemo from RosCon 2022 to support the latest 23.10 release. 
* Add support to use the new Project Exporter script that will create a release-build package of the project. This reduces the size of the docker image significantly when creating a docker image just to run the simulation.
* Fix a monolithic-release build issue related to the `RosconDemo` gem adding a dependency to `            Gem::AtomLyIntegration_CommonFeatures.Editor.Static` which is an editor target.
* Add a patch necessary to build the launcher in release build against release 23.10 (this will be fixed in the future)
* Perform optimization to the Dockerfile scripts to reduce the size and steps as much as possible
* Update the docker read me to describe the changes 
