### PR TITLE
Change ROS2FrameComponent to ROS2FrameEditorComponent (next release)

### DIFF
--- a/Project/Assets/Importer/myfirst.prefab
+++ b/Project/Assets/Importer/myfirst.prefab
@@ -181,10 +181,9 @@
                     }
                 },
                 "Component_[15581930040980741279]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 15581930040980741279,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "link2"
                     }
                 },
@@ -284,10 +283,9 @@
                     "Id": 11253416261782360310
                 },
                 "Component_[13566261617107914927]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 13566261617107914927,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "link1"
                     }
                 },
@@ -488,10 +486,9 @@
                     "Id": 17871258124168575381
                 },
                 "Component_[3122846594690437805]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 3122846594690437805,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "base_wheel"
                     }
                 },

--- a/Project/Assets/Kraken/apple_kraken_v1/apple_kraken_v1.prefab
+++ b/Project/Assets/Kraken/apple_kraken_v1/apple_kraken_v1.prefab
@@ -450,10 +450,9 @@
                     }
                 },
                 "Component_[839061643917149005]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 839061643917149005,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "kraken_manipulator_link_4"
                     }
                 },
@@ -634,10 +633,9 @@
                     }
                 },
                 "Component_[3950558941332218098]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 3950558941332218098,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "steering_front_right_link"
                     }
                 },
@@ -945,10 +943,9 @@
                     "Id": 12574681316984350453
                 },
                 "Component_[12589217388276244759]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 12589217388276244759,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_front_left_link"
                     }
                 },
@@ -1190,10 +1187,9 @@
                     }
                 },
                 "Component_[17312067275736616703]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 17312067275736616703,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "kraken_manipulator_link_0"
                     }
                 },
@@ -1531,10 +1527,9 @@
                     "Id": 8857359616044755216
                 },
                 "Component_[9145617912145528580]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 9145617912145528580,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "kraken_manipulator_link_2"
                     }
                 },
@@ -1955,10 +1950,9 @@
                     }
                 },
                 "Component_[2169386371792618257]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 2169386371792618257,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_rear_left_link"
                     }
                 },
@@ -2130,10 +2124,9 @@
                     }
                 },
                 "Component_[2213009497670964234]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 2213009497670964234,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_rear_right_link"
                     }
                 },
@@ -2434,10 +2427,9 @@
                     "Id": 6853700600595112405
                 },
                 "Component_[8600248634478648640]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 8600248634478648640,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_front_right_link"
                     }
                 }
@@ -2866,10 +2858,9 @@
                     }
                 },
                 "Component_[5918697870879483153]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 5918697870879483153,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 2
                         },
@@ -3029,10 +3020,9 @@
                     }
                 },
                 "Component_[6517663388098082332]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 6517663388098082332,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "kraken_manipulator_link_1"
                     }
                 },
@@ -3134,10 +3124,9 @@
                     "Id": 18116517932786798066
                 },
                 "Component_[2414989753236822341]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 2414989753236822341,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "steering_front_left_link"
                     }
                 },
@@ -3503,10 +3492,9 @@
                     "Id": 17075071070477116796
                 },
                 "Component_[18376511454985353613]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 18376511454985353613,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },
@@ -3572,10 +3560,9 @@
             "Name": "Sensor",
             "Components": {
                 "Component_[1058300359310703890]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 1058300359310703890,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },

--- a/Project/Assets/Kraken/apple_kraken_v2/apple_kraken_v2.prefab
+++ b/Project/Assets/Kraken/apple_kraken_v2/apple_kraken_v2.prefab
@@ -548,10 +548,9 @@
                     }
                 },
                 "Component_[839061643917149005]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 839061643917149005,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "kraken_manipulator_link_4"
                     }
                 },
@@ -729,10 +728,9 @@
                     }
                 },
                 "Component_[3950558941332218098]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 3950558941332218098,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "steering_front_right_link"
                     }
                 },
@@ -1097,10 +1095,9 @@
                     "Id": 12574681316984350453
                 },
                 "Component_[12589217388276244759]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 12589217388276244759,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_front_left_link"
                     }
                 },
@@ -1360,10 +1357,9 @@
                     }
                 },
                 "Component_[17312067275736616703]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 17312067275736616703,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "kraken_manipulator_link_0"
                     }
                 },
@@ -1697,10 +1693,9 @@
                     "Id": 8857359616044755216
                 },
                 "Component_[9145617912145528580]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 9145617912145528580,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "kraken_manipulator_link_2"
                     }
                 },
@@ -2219,10 +2214,9 @@
                     }
                 },
                 "Component_[2169386371792618257]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 2169386371792618257,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_rear_left_link"
                     }
                 },
@@ -2395,10 +2389,9 @@
                     }
                 },
                 "Component_[2213009497670964234]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 2213009497670964234,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_rear_right_link"
                     }
                 },
@@ -2700,10 +2693,9 @@
                     "Id": 6853700600595112405
                 },
                 "Component_[8600248634478648640]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 8600248634478648640,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_front_right_link"
                     }
                 }
@@ -3110,10 +3102,9 @@
                     }
                 },
                 "Component_[5918697870879483153]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 5918697870879483153,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 2
                         },
@@ -3285,10 +3276,9 @@
                     }
                 },
                 "Component_[6517663388098082332]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 6517663388098082332,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "kraken_manipulator_link_1"
                     }
                 },
@@ -3387,10 +3377,9 @@
                     "Id": 18116517932786798066
                 },
                 "Component_[2414989753236822341]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 2414989753236822341,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "steering_front_left_link"
                     }
                 },
@@ -4315,10 +4304,9 @@
                     "Id": 6868930103042649999
                 },
                 "Component_[747584382186458865]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 747584382186458865,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "lidar_mount"
                     }
                 },
@@ -4340,10 +4328,9 @@
             "Name": "Sensor",
             "Components": {
                 "Component_[1058300359310703890]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 1058300359310703890,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },

--- a/Project/Levels/Main/Main.prefab
+++ b/Project/Levels/Main/Main.prefab
@@ -5527,7 +5527,6 @@
                             "Name": "line2"
                         }
                     }
-
                 },
                 "Component_[2840753425454738983]": {
                     "$type": "EditorLockComponent",

--- a/Project/Prefabs/LidarKraken.prefab
+++ b/Project/Prefabs/LidarKraken.prefab
@@ -170,10 +170,9 @@
             "Name": "Sensor",
             "Components": {
                 "Component_[1058300359310703890]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 1058300359310703890,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },

--- a/Project/project.json
+++ b/Project/project.json
@@ -18,7 +18,7 @@
     ],
     "restricted": "ROSConDemo",
     "gem_names": [
-        "ROS2"
+        "ROS2==3.0.0"
     ],
     "engine_version": "2.1.0"
 }


### PR DESCRIPTION
**Breaking change**
This PR is in reference to https://github.com/o3de/o3de-extras/pull/593.

I've updated all prefabs to include the ROS2FrameEditorComponent instead of the ROS2FrameComponent.